### PR TITLE
docs: mark smoke-test checklist items as passed

### DIFF
--- a/docs/mvp-release-checklist.md
+++ b/docs/mvp-release-checklist.md
@@ -138,7 +138,7 @@ make -C demo allow
 
 Expected: `"isError": false` and mock file contents in the response.
 
-- [ ] Allow response contains `"isError": false`
+- [x] Allow response contains `"isError": false`
 
 **Denied call — `write_file` (not in manifest):**
 
@@ -148,7 +148,7 @@ make -C demo deny
 
 Expected: `"isError": true` and `"code":"AUTHORIZATION_FAILED"`.
 
-- [ ] Deny response contains `AUTHORIZATION_FAILED`
+- [x] Deny response contains `AUTHORIZATION_FAILED`
 
 **Denied call — `read_file /etc/shadow` (wrong path):**
 
@@ -158,7 +158,7 @@ make -C demo deny-path
 
 Expected: `"isError": true` and `"code":"CONDITION_FAILED"` with `"argument":"path"` in details.
 
-- [ ] Deny response contains `CONDITION_FAILED`
+- [x] Deny response contains `CONDITION_FAILED`
 
 **Denied call — `query_db DELETE` (wrong SQL op):**
 
@@ -168,7 +168,7 @@ make -C demo deny-op
 
 Expected: `"isError": true` and `"code":"CONDITION_FAILED"` with `"allowedOperations"` in details.
 
-- [ ] Deny response contains `CONDITION_FAILED`
+- [x] Deny response contains `CONDITION_FAILED`
 
 **Audit log — verify records and HMAC chain:**
 
@@ -199,7 +199,7 @@ make -C demo ci-test
 
 This starts the stack, runs all assertions from `demo/scripts/ci-test.sh`, and tears down. Expect `Results: 8 passed, 0 failed`.
 
-- [ ] `ci-test` exits 0 with 8/8 passing
+- [x] `ci-test` exits 0 with 8/8 passing
 
 ### 3b — JWT mode (manifest + IdP claims)
 


### PR DESCRIPTION
## Summary

- Ticks off 5 manual verification steps in the MVP release checklist that have been confirmed passing:
  - Allow response contains `"isError": false`
  - Deny response contains `AUTHORIZATION_FAILED`
  - Deny-path response contains `CONDITION_FAILED`
  - Deny-op response contains `CONDITION_FAILED`
  - `ci-test` exits 0 with 8/8 passing

## Test plan

- [ ] No code changes — checklist-only update reflecting completed manual smoke tests
- [ ] Reviewer can confirm these results by running `make -C demo ci-test` (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)