### PR TITLE
docs: rewrite capability-manifest-guide to reflect actual enforcement mechanics

### DIFF
--- a/docs/capability-manifest-guide.md
+++ b/docs/capability-manifest-guide.md
@@ -13,29 +13,71 @@ mechanically.
 
 ## 1. Required structure
 
-Every manifest must match `AgentCapabilityManifest` in
-`internal/agentruntime/manifest.go`. The required top-level fields are
-`name`, `version`, and `capabilities`. Optional fields are
-`description`, `defaultTtl`, and `audience`. Anything missing or shaped
-differently is rejected by `eunox validate`.
+The required top-level fields are `name`, `version`, and `capabilities`.
+Optional fields are `description`, `defaultTtl`, and `audience`.
+Anything missing or shaped differently is rejected by `eunox-mcp validate`.
 
 ```yaml
-name: "Sales Research Bot" # human-readable
-version: "0.1.0" # agent version (semver)
-capabilities: [] # see § 2 — every entry is a capability.Constraint
-description: "Synthesizes account-research briefings."
-defaultTtl: 600 # optional
-audience: "eunox" # optional
+name: "Sales Research Bot" # human-readable, unique per logical agent
+version: "0.1.0"           # semver; recorded in every audit log entry
+capabilities: []           # see § 2 — each entry is a capability constraint
+description: "Synthesizes account-research briefings." # optional
+defaultTtl: 600            # informational only — not enforced by the proxy
+audience: "eunox"          # optional; used in JWT-intersection mode
 ```
 
-The `defaultTtl` and `audience` fields are parsed and stored but are
-informational in the proxy — JWT expiry is enforced by your IdP, not
-by eunox-mcp. See § 5 for TTL guidance.
+The `defaultTtl` and `audience` fields are informational in the proxy —
+JWT expiry is enforced by your IdP, not by eunox-mcp. See § 5 for TTL
+guidance.
 
-## 2. The capability list — the four common patterns
+## 2. How enforcement works
 
-Most manifests fall into one of four shapes. Start from the closest
-one and resist the urge to invent new shapes unless none of these fits.
+Before writing a manifest, understand what the proxy actually checks.
+
+**Resource** — matched against the MCP tool name.
+
+Every `tools/call` request carries a `name` field (e.g. `read_file`,
+`query_db`, `get_customer`). The proxy matches that string against each
+capability entry's `resource` field using `path.Match` glob semantics.
+There are no resource URIs, paths, or URLs in the MCP protocol — only
+tool names. `resource: "get_*"` matches any tool whose name starts with
+`get_`; `resource: read_file` matches only the tool named `read_file`
+exactly.
+
+**Actions** — two modes.
+
+Once a matching capability is found, the proxy checks whether the call
+is permitted by the `actions` list. There are two modes:
+
+| Mode | `actions` value | How it works |
+|---|---|---|
+| Generic | `[call]` or `[*]` | Permits any `tools/call` for the matched resource. This is the safe default and what the demo uses. |
+| Semantic | `[read]`, `[write]`, `[delete]`, `[execute]`, `[admin]` | The tool name is classified into a category by the resolver chain (see below). The call is permitted only if the resolved category appears in the list. |
+
+**Semantic action resolver chain** (evaluated in order):
+
+1. **Static resolver** — an explicit `tool_name → category` map
+   supplied via a profile (`eunox-mcp profiles`) or a custom action-map
+   file. Exact lookups, O(1).
+2. **HeuristicResolver** — infers the category from the tool name
+   prefix when no static entry exists:
+
+   | Category | Matched prefixes |
+   |---|---|
+   | `read` | `get_`, `list_`, `search_`, `read_`, `describe_`, `fetch_`, `show_`, `find_`, `query_`, `view_`, `check_`, `inspect_`, `peek_`, `stat_`, `open_` |
+   | `write` | `create_`, `update_`, `write_`, `set_`, `put_`, `post_`, `send_`, `add_`, `insert_`, `upsert_`, `patch_`, `edit_`, `modify_`, `push_`, `upload_`, `save_`, `append_`, `publish_`, `fork_`, `merge_` |
+   | `delete` | `delete_`, `remove_`, `drop_`, `purge_`, `destroy_`, `archive_`, `close_`, `clear_` |
+   | `execute` | `run_`, `execute_`, `launch_`, `start_`, `stop_`, `restart_`, `invoke_`, `trigger_`, `apply_`, `deploy_`, `install_`, `eval_` |
+   | `admin` | `admin_`, `grant_`, `revoke_`, `promote_`, `demote_`, `approve_`, `reject_` |
+
+3. **Fallback** — if neither resolver classifies the tool and `actions`
+   does not include `call` or `*`, the call is denied.
+
+> **Practical advice:** use `actions: [call]` unless you have a specific
+> reason to restrict by semantic category. It is clear, always works,
+> and does not depend on tool naming conventions.
+
+## 3. The capability list — four common patterns
 
 ### Pattern A — Single-purpose read agent
 
@@ -43,61 +85,72 @@ one and resist the urge to invent new shapes unless none of these fits.
 
 ```yaml
 capabilities:
-  - resource: "api://crm/customers/*"
-    actions: ["read"]
-  - resource: "api://reports/*"
-    actions: ["read"]
+  - resource: "get_*"       # matches get_customer, get_invoice, get_report …
+    actions: [call]
+  - resource: "list_*"      # matches list_customers, list_orders …
+    actions: [call]
+  - resource: "search_*"    # matches search_products, search_tickets …
+    actions: [call]
 ```
 
-- Only `read`.
-- Resources scoped to a _segment_ with `/*`, never bare `*`.
-- The Sentinel rule **"Write attempt from a read-only session"** will
-  fire immediately if this agent ever attempts a write — that's the
-  intended behaviour and it is **not** a false positive. Investigate
-  before widening the manifest.
+- Use `actions: [call]` — it is unconditional for any matched tool.
+- Scope each resource glob to one verb prefix. Do not write
+  `resource: "*"` (rejected by `eunox-mcp validate`) or
+  `resource: "get_or_list_*"` (not how glob patterns work).
+- If the agent should only call a small fixed set of tools, list them
+  individually rather than using a prefix glob — narrow is always safer.
 
-### Pattern B — Workflow agent (read-most, narrow write)
+  ```yaml
+  capabilities:
+    - resource: get_customer
+      actions: [call]
+    - resource: list_orders
+      actions: [call]
+  ```
 
-> _"This agent reads broadly but only writes back to one specific path."_
+### Pattern B — Workflow agent (read-many, narrow write)
+
+> _"This agent reads broadly but writes to exactly one tool."_
 
 ```yaml
 capabilities:
-  - resource: "api://crm/customers/*"
-    actions: ["read"]
-  - resource: "api://crm/customers/*/notes"
-    actions: ["write"]
-  - resource: "api://reports/*"
-    actions: ["read"]
+  - resource: "get_*"           # reads — broad
+    actions: [call]
+  - resource: "list_*"          # reads — broad
+    actions: [call]
+  - resource: add_customer_note # single permitted write tool — explicit
+    actions: [call]
+  # create_*, update_*, delete_* are absent → denied by default
 ```
 
-- Write resource is a **child path** of the read resource.
-- Each write resource lists explicit actions; never use
-  `["read", "write", "delete"]` "just in case".
-- If the agent needs to write into N siblings, list them
-  individually — don't widen to `api://crm/*`.
+- There are no resource paths in MCP — you control access by
+  **naming the write tools explicitly**, not by restricting to a path prefix.
+- Never add a write tool "just in case it's needed later".
+  Every write capability you add is blast radius.
+- If the agent genuinely needs several write tools, list each one
+  individually rather than widening to `"create_*"` or `"*"`.
 
 ### Pattern C — Tool-specialist agent
 
-> _"This agent calls a single internal tool a lot, with arguments."_
+> _"This agent calls one specific tool many times, with argument constraints."_
 
 ```yaml
 capabilities:
-  - resource: "api://forecasting/predict"
-    actions: ["execute"]
+  - resource: run_forecast      # exact tool name
+    actions: [call]
     conditions:
-      - type: maxCalls # MaxCallsCondition
+      - type: maxCalls           # at most 30 calls per minute
         count: 30
         windowSeconds: 60
-      - type: allowedOperations # AllowedOperationsCondition (narrows the verb)
+      - type: allowedOperations  # narrow the operation verb further
         operations: ["predict"]
 ```
 
-- Use `execute` for RPC-style endpoints.
-- Apply typed conditions instead of relying on TTL alone.
-- Each entry is one of the typed condition shapes in
-  `pkg/capability/condition.go`; the proxy enforces them through the
-  `ConditionRegistry` — no new validator code is needed if the type
-  already exists.
+- Use the exact tool name, not a glob — you want this constraint to
+  apply to precisely one tool.
+- Apply typed conditions to constrain arguments and rate. Each condition
+  is one of the typed shapes in `pkg/capability/condition.go`.
+- See § 4 for the full condition type reference.
 
 ### Pattern D — JWT-scoped agent (manifest + IdP intersection)
 
@@ -117,16 +170,13 @@ capabilities:
     actions: [call]
 ```
 
-The IdP then issues a JWT carrying a narrower `mcp.capabilities` claim:
+The IdP then issues a JWT carrying a narrower `eunox.capabilities` claim:
 
 ```json
 {
-  "mcp": {
-    "v": "0.1",
-    "capabilities": ["read_file:/reports/q3.pdf"],
-    "agent_id": "summariser-run-42",
-    "task_id": "briefing-2026-05-31"
-  }
+  "eunox.capabilities": ["read_file:/reports/q3.pdf"],
+  "eunox.agent_id": "summariser-run-42",
+  "eunox.task_id": "briefing-2026-05-31"
 }
 ```
 
@@ -137,98 +187,120 @@ invocation even though the manifest allows it.
 - Start the proxy in JWT mode: `--jwks-uri <url> --jwt-issuer <iss> --jwt-audience eunox --policy manifest.yaml`
 - The audit log records `agent_id` and `task_id` from the JWT automatically.
 
-## 3. Resource pattern do's and don'ts
+## 4. Resource pattern reference
 
-The wildcard semantics are **segment-aware** (`pkg/enforcement/engine.go::matchesResource`).
-Internalize the table below.
+The `resource` field is matched against the MCP **tool name** using
+`path.Match`. Because tool names rarely contain `/`, the `*` wildcard
+effectively matches any suffix within a single naming segment.
 
-| Pattern                 | Matches                              | Does **not** match                     |
-| ----------------------- | ------------------------------------ | -------------------------------------- |
-| `api://crm/customers`   | `api://crm/customers` only           | `api://crm/customers/123`              |
-| `api://crm/customers/*` | `api://crm/customers/123`, `.../abc` | `api://crm/customers`, `.../123/notes` |
-| `storage://docs/team/*` | `storage://docs/team/file.pdf`       | `storage://docs/file.pdf`              |
-| `api://*`               | (rejected by `eunox validate`)       | —                                      |
+| Pattern | Matches | Does **not** match |
+|---|---|---|
+| `get_customer` | `get_customer` only | `get_customers`, `get_customer_by_id` |
+| `get_*` | `get_customer`, `get_invoice`, `get_report` | `list_customers`, `create_customer` |
+| `*_report` | `get_report`, `create_report`, `delete_report` | `report_get`, `reports` |
+| `read_file` | `read_file` only | `read_files`, `read_file_metadata` |
+| `*` | (rejected by `eunox-mcp validate`) | — |
 
 Rules:
 
-- **Schemes are equality-checked.** `api://` and `storage://` never
-  cross-match.
-- **`*` matches one segment only.** `api://crm/customers/*` matches
-  `api://crm/customers/123` but not `api://crm/customers/123/notes`.
-  Multi-segment wildcards (`**`) are not supported — `path.Match`
-  semantics are used and treat `**` identically to `*`.
-- **Bare `*` is not allowed.** `eunox-mcp validate` rejects it.
+- **Match is against the tool name string.** There are no resource URIs,
+  HTTP paths, or URL schemes in the MCP protocol.
+- **`*` matches any characters except `/`.** Since most tool names do not
+  contain `/`, this is effectively a substring wildcard, but it will not
+  span a `/` if one appears.
+- **Multi-segment wildcards (`**`) are not supported.** `path.Match`
+  treats `**` identically to `*`.
+- **Bare `*` is rejected** by `eunox-mcp validate`. Use named tools or
+  specific prefix globs instead.
+- **Most-specific match wins.** If two entries both match a tool name,
+  the one with the higher specificity score (exact > no-wildcard prefix >
+  shorter wildcard) is used.
 
-## 4. Conditions cookbook
+## 5. Conditions cookbook
 
 `conditions` is an array of typed shapes from
-`pkg/capability/condition.go` and `pkg/capability/conditions.go`.
-Every entry has a `type` discriminator and is enforced by the shared
-`ConditionRegistry`. Unknown types are denied at both issuance and at
-the proxy, so spelling matters.
+`pkg/capability/condition.go`. Every entry has a `type` discriminator.
+Unknown types are denied at the proxy, so spelling matters.
 
 ```yaml
-- resource: "api://billing/invoices/*"
-  actions: ["read"]
+# Rate-limit, time-window, and IP-allowlist on a reporting tool
+- resource: get_invoice
+  actions: [call]
   conditions:
-    - type: maxCalls # rate-limit
+    - type: maxCalls        # at most 60 calls per minute
       count: 60
       windowSeconds: 60
-    - type: timeWindow # restrict to a window
+    - type: timeWindow      # restrict to a fiscal-year window
       notBefore: "2026-04-01T00:00:00Z"
       notAfter: "2026-12-31T23:59:59Z"
-    - type: ipRange # source-IP allowlist
+    - type: ipRange         # internal network only
       cidrs: ["10.0.0.0/8"]
 
-- resource: "storage://exports/team-a/*"
-  actions: ["write"]
+# Restrict file exports to safe types
+- resource: export_data
+  actions: [call]
   conditions:
-    - type: allowedExtensions # restrict file types
+    - type: allowedExtensions
       extensions: [".csv", ".json"]
 
-- resource: "db://warehouse/sales"
-  actions: ["read"]
+# Database query tool: restrict tables and redact a column
+- resource: query_sales
+  actions: [call]
   conditions:
-    - type: allowedTables # restrict tables (and optionally columns)
+    - type: allowedTables
       tables: ["sales"]
       columns:
         sales: ["customer_id", "amount", "ts"]
-    - type: redactFields # proxy records the redaction obligation
+    - type: redactFields       # proxy strips this field from the result
       fields: ["sales.customer_email"]
 
-- resource: "smtp://outbound/*"
-  actions: ["execute"]
+# Email tool: allowlist recipient domains
+- resource: send_email
+  actions: [call]
   conditions:
-    - type: recipientDomain # outbound email allowlist
+    - type: recipientDomain
       domains: ["example.com"]
 ```
 
-The full list of shipped condition types is `timeWindow`, `ipRange`,
+The full list of shipped condition types: `timeWindow`, `ipRange`,
 `allowedOperations`, `allowedExtensions`, `allowedTables`, `maxCalls`,
 `recipientDomain`, `redactFields`, `allowedValues`, `policy`,
-and the `custom` escape hatch (which requires the named handler to be
-registered in the `ConditionRegistry`).
+and the `custom` escape hatch (requires the named handler to be
+registered via `RegisterCondition`).
 
-**`allowedValues`** — restricts a named string argument to a set of allowed
+**`allowedValues`** — restricts a named tool argument to a set of allowed
 literal values or glob patterns:
 
 ```yaml
 - resource: read_file
+  actions: [call]
   conditions:
     - type: allowedValues   # restrict the path argument
       argument: path
       values: ["/reports/*", "/public/*"]
 ```
 
-The `argument` field names the tool parameter to check; `values` is a list
-of exact strings or `*`-glob patterns (e.g. `/reports/*` matches
+The `argument` field names the tool parameter to check; `values` is a
+list of exact strings or `*`-glob patterns (e.g. `/reports/*` matches
 `/reports/q3.pdf`).
+
+**`allowedOperations`** — restricts the SQL verb or operation keyword
+extracted from a tool argument named `sql`, `query`, or `statement`:
+
+```yaml
+- resource: query_db
+  actions: [call]
+  conditions:
+    - type: allowedOperations
+      operations: ["SELECT"]   # blocks INSERT, UPDATE, DELETE, DROP, …
+```
 
 **`policy`** — delegates the allow/deny decision to an external policy
 decision point (e.g. OPA, Cedar) registered via `WithPolicyEvaluator`:
 
 ```yaml
 - resource: query_db
+  actions: [call]
   conditions:
     - type: policy
       backend: opa          # name passed to your registered PolicyEvaluator
@@ -243,14 +315,14 @@ When no evaluator is wired (the default), any `policy` condition is
 denied fail-closed. Use this for logic that cannot be expressed with
 the other typed conditions.
 
-> If a condition you need is not in the union, **add a new typed
-> shape to `pkg/capability/condition.go` first**, register its
-> handler in `pkg/enforcement/handlers.go`, and ship a
-> validator with tests under `pkg/capability/validate.go`.
-> Free-form conditions are denied at the proxy, which is the correct
-> behaviour but a policy regression for the manifest author.
+> If a condition type you need does not exist, **add a new typed shape
+> to `pkg/capability/condition.go` first**, register its handler in
+> `pkg/enforcement/handlers.go`, and ship a test.
+> Unknown condition types are denied at the proxy — that is the correct
+> behaviour, but a regression for the manifest author if they forget to
+> register the handler.
 
-## 5. TTL guidance
+## 6. TTL guidance
 
 In JWT mode, token lifetime is controlled by the `exp` claim your IdP
 stamps on the JWT — eunox-mcp validates and rejects expired tokens but
@@ -267,7 +339,7 @@ and available for your tooling to read; the proxy does not enforce it.
 Configure short TTLs in your IdP client settings; request a fresh
 token per task rather than re-using a long-lived one.
 
-## 6. Anti-patterns to avoid
+## 7. Anti-patterns to avoid
 
 These all _work_ (token issued, proxy happy) but each one silently
 degrades the security posture.
@@ -278,7 +350,7 @@ degrades the security posture.
 2. **Over-broad resource globs** "for development". Configure dev
    manifests with realistic scopes from day one — a manifest that is
    too wide in development tends to stay that way in production.
-3. **Adding actions the agent doesn't currently need.** List only what
+3. **Adding tools the agent doesn't currently need.** List only what
    the agent actually calls. Over-broad manifests silently widen the
    blast radius of a prompt-injection or supply-chain compromise.
 4. **One manifest shared across every environment.** Use a separate
@@ -289,7 +361,7 @@ degrades the security posture.
    per task and keep TTLs short; the audit log records `task_id` from
    the JWT so attribution is preserved without needing long-lived tokens.
 
-## 7. Tooling
+## 8. Tooling
 
 | Step                                          | CLI command                                          |
 | --------------------------------------------- | ---------------------------------------------------- |
@@ -304,8 +376,7 @@ degrades the security posture.
 Wire `eunox-mcp validate` into your CI pipeline for every manifest PR
 to catch schema errors and over-broad globs before they reach production.
 
-## 8. Where this guide lives in the rest of the docs
+## 9. Where this guide lives in the rest of the docs
 
-- **Why the proxy is the policy decision point**: [`enforcement.md`](./enforcement.md)
 - **Security properties and threat model**: [`threat-model-mcp.md`](./threat-model-mcp.md)
 - **Performance baseline**: [`benchmarks.md`](./benchmarks.md)

--- a/docs/mcp-enforcement-gaps.md
+++ b/docs/mcp-enforcement-gaps.md
@@ -1,0 +1,277 @@
+# MCP Enforcement Gap Analysis
+
+**Date:** 2026-05-31  
+**Status:** Discovery / decision pending  
+**Context:** eunox-mcp MVP (v0.1.0) enforces policy only on `tools/call`. The
+MCP 2025-11-25 protocol defines a broader message surface. This report
+catalogues the unguarded methods, assesses their risk, and recommends
+what to address before the MVP ships vs. what to defer.
+
+---
+
+## Background
+
+The proxy intercepts every JSON-RPC message that flows between the MCP
+host (Claude Desktop, LangChain, etc.) and the upstream MCP server.
+Its routing logic has three branches:
+
+```
+msg.Method == "initialize"  → proxy answers directly (no upstream call)
+msg.Method == "tools/call"  → PDP enforcement → conditional upstream call
+anything else               → forwarded verbatim to upstream
+```
+
+Everything in the third branch bypasses the capability manifest entirely.
+The following sections audit that surface.
+
+---
+
+## Gap inventory
+
+### Gap 1 — `resources/read` (Severity: **High**)
+
+**What it is.** MCP servers can expose _resources_ — files, database rows,
+API results, live data feeds — identified by a URI (e.g.
+`file:///data/customers.csv`, `db://warehouse/orders`). A host reads a
+resource by sending `resources/read` with that URI.
+
+**What currently happens.** The request is forwarded verbatim. The manifest
+is not consulted. An agent can read any resource the server exposes,
+regardless of what the manifest permits.
+
+**Risk.** This is the same class of problem that `tools/call` enforcement
+solves, applied to the resource primitive. A manifest that carefully
+restricts which _tools_ the agent can call silently permits unrestricted
+_resource_ access. In practice, MCP servers that expose sensitive data
+frequently do so via resources rather than tools (e.g. the filesystem
+server, the database server, the GitHub server's repository contents).
+
+**Exploitability.** Moderate to high. Requires the upstream server to
+expose resources _and_ the agent or a prompt-injection payload to know
+the resource URI. Discovery via `resources/list` (also unguarded — see
+Gap 2) lowers this bar significantly.
+
+**Effort to fix.** Low-to-medium. The enforcement engine already supports
+glob-based resource patterns, `allowedValues` conditions (for URI
+filtering), and the full condition set. The proxy needs to route
+`resources/read` through `handleHTTPToolsCall`-equivalent logic, using
+the resource URI as the tool name for matching. No new manifest syntax
+is required — the existing `resource` field and `actions` vocabulary
+apply directly:
+
+```yaml
+capabilities:
+  - resource: "file:///data/reports/*"   # resource URI glob
+    actions: [read]
+```
+
+---
+
+### Gap 2 — `tools/list` (Severity: **Medium**)
+
+**What it is.** `tools/list` returns the full catalogue of tools the
+upstream server exposes. The host uses this list to know what it can
+call; the LLM uses it to decide what to invoke.
+
+**What currently happens.** The full tool list is returned to the host
+unfiltered. The host and model see every tool the server exposes, even
+tools that the manifest blocks from being called.
+
+**Risk.** Two issues:
+
+1. **Capability surface leakage.** An agent (or an attacker who has
+   achieved prompt injection) can enumerate all available tools —
+   including blocked ones — by issuing `tools/list`. This gives a
+   detailed map of what to attempt.
+
+2. **Model confusion.** The LLM receives descriptions for tools it
+   cannot call. If it attempts them it gets a denial with an error
+   message that reveals the manifest's structure. At scale, a
+   manipulated model can use repeated denied calls to probe the
+   policy boundary.
+
+**Exploitability.** Low standalone risk — an attacker still cannot
+_call_ a blocked tool — but it meaningfully aids other attacks.
+
+**Effort to fix.** Low. The proxy already holds the manifest at the time
+`tools/list` is received. Filtering the upstream response to only
+include tools whose names match at least one manifest `resource` entry
+is a straightforward post-processing step. No new manifest syntax needed.
+
+---
+
+### Gap 3 — `resources/list` and `resources/subscribe` (Severity: **Low–Medium**)
+
+**What it is.** `resources/list` enumerates available resources.
+`resources/subscribe` establishes a live update channel for a specific
+resource URI.
+
+**What currently happens.** Both are forwarded verbatim.
+
+**Risk.** `resources/list` has the same discovery-aid problem as
+`tools/list` (Gap 2) applied to resources. `resources/subscribe` is
+more concerning: it opens an ongoing channel for data to flow to the
+host without any per-read policy check. If Gap 1 is fixed
+(`resources/read` enforcement) but `resources/subscribe` is left open,
+a determined agent can use subscriptions to receive resource updates
+continuously.
+
+**Exploitability.** Low without Gap 1 also being exploited. Addressed
+naturally once `resources/read` is enforced — subscriptions should be
+subject to the same resource policy as reads.
+
+**Effort to fix.** Medium (filtering `resources/list`); High
+(`resources/subscribe` requires stateful tracking of subscriptions
+against the manifest, plus enforcement on the async update stream).
+
+---
+
+### Gap 4 — `prompts/get` (Severity: **Medium**)
+
+**What it is.** MCP servers can expose _prompts_ — named, parameterised
+instruction templates that the host injects into the conversation. A
+prompt is not static text; it is executable model instruction.
+
+**What currently happens.** `prompts/get` is forwarded verbatim. Any
+agent can retrieve any prompt the server exposes.
+
+**Risk.** A prompt is a policy bypass vector. A manifest can block
+`write_file` as a tool call, but a prompt retrieved via `prompts/get`
+can instruct the model to call `write_file` as part of a multi-turn
+plan. The proxy never sees the instruction in that form — it only sees
+the resulting `tools/call`, which it does enforce. However, a malicious
+prompt can construct chains that collectively circumvent individual
+tool-call restrictions.
+
+Additionally, prompt templates can themselves contain sensitive data
+(system instructions, internal API schemas, operational runbooks) that
+an agent should not be able to exfiltrate by reading them.
+
+**Exploitability.** Moderate. Requires a server that exposes prompts _and_
+a model that follows injected prompt instructions without resistance.
+
+**Effort to fix.** Medium. Requires deciding on the manifest vocabulary
+for prompts (prompt names vs. resource URIs) and adding a `prompts/get`
+enforcement branch. No new condition types needed. Prompt _filtering_
+(inspecting prompt content for policy violations) is a separate, much
+harder problem (LLM-based) and is out of scope.
+
+---
+
+### Gap 5 — `sampling/createMessage` (Severity: **High**; direction: server→client)
+
+**What it is.** MCP 2025-11-25 allows the _server_ to request that the
+_host LLM_ generate a message — the reverse of the normal flow. The
+server sends `sampling/createMessage` to the proxy, which forwards it
+to the host, which calls the model and returns the result to the server.
+
+**What currently happens.** The request is forwarded verbatim in both
+directions. The manifest is not consulted.
+
+**Risk.** This is the most structurally dangerous gap in the current
+proxy architecture. A compromised, malicious, or prompt-injected
+upstream server can:
+
+- **Exfiltrate conversation history** by requesting a model completion
+  that summarises or repeats it.
+- **Invoke tool calls indirectly** by generating model output that
+  contains tool invocations the host then executes.
+- **Impersonate the user** by generating messages in the user's voice.
+- **Escape the session context** by establishing a separate model
+  dialogue the operator cannot see.
+
+The current proxy enforces what the _agent_ requests. `sampling/createMessage`
+is a channel the _server_ controls, which means any enforcement model
+built only around agent behaviour is insufficient if this channel is
+open.
+
+**Exploitability.** Requires the host to support the `sampling` capability
+(Claude Desktop does; not all hosts do). If supported, the risk is real
+and requires no agent cooperation — the server acts alone.
+
+**Effort to fix.** High. Requires:
+
+1. A new enforcement direction (server→client) and a new manifest
+   concept — the existing `resource`/`actions` model is agent→server
+   only.
+2. Deciding what "allow/deny sampling" means in policy terms
+   (per-server allowlist? max tokens? allowed model parameters?).
+3. Inspecting and potentially rejecting the _result_ of sampling before
+   returning it to the server — currently there is no hook for this.
+
+A minimal first step — **denying `sampling/createMessage` by default
+unless the manifest explicitly allows it** — is low effort and
+eliminates the most dangerous failure mode. Full parametric control is
+a post-MVP workstream.
+
+---
+
+## Priority matrix
+
+| Gap | Severity | Exploitability | Effort | MVP? |
+|---|---|---|---|---|
+| Gap 5 — `sampling/createMessage` | High | High (if host supports it) | Medium (deny-by-default) / High (full control) | **Yes — deny-by-default** |
+| Gap 1 — `resources/read` | High | Moderate | Low–Medium | **Yes** |
+| Gap 2 — `tools/list` filtering | Medium | Low | Low | **Yes** |
+| Gap 4 — `prompts/get` | Medium | Moderate | Medium | **Borderline — see below** |
+| Gap 3 — `resources/list` filtering | Low–Medium | Low | Low | No |
+| Gap 3 — `resources/subscribe` | Low–Medium | Low | High | No |
+
+---
+
+## Recommendations
+
+### Ship before MVP
+
+**Gap 5 — deny `sampling/createMessage` by default.**
+The implementation cost is minimal: add `"sampling/createMessage"` to
+the enforced method set and return a JSON-RPC error unless the manifest
+explicitly contains a `sampling` capability entry (or a new
+`--allow-sampling` flag). This converts a high-severity open channel
+into an explicit opt-in. Operators who need server-initiated sampling
+can enable it; everyone else is protected without writing any new
+manifest entries.
+
+**Gap 1 — enforce `resources/read`.**
+Extend the PDP routing to intercept `resources/read` and run it through
+the same `findConstraint`/condition-evaluation path as `tools/call`,
+using the resource URI as the match target. Manifests that do not
+include resource entries deny all resource reads by default — consistent
+with the existing allowlist semantics for tools. This closes the most
+direct data-exfiltration path and is essential for servers that expose
+sensitive data as resources (filesystem, database, GitHub content).
+
+**Gap 2 — filter `tools/list` to permitted tools.**
+The proxy holds the manifest; filtering the upstream `tools/list`
+response to only the entries whose tool names match a manifest
+`resource` pattern is a small post-processing step. This eliminates
+the capability-surface leak and reduces the information available
+to prompt-injection attacks.
+
+### Defer to post-MVP
+
+**Gap 4 — `prompts/get`.** The risk is real but the manifest vocabulary
+for prompt-name matching is not designed yet, and the harder problem
+(prompt _content_ inspection) is out of scope for any near-term release.
+Defer, but document that `prompts/get` is unguarded so operators can
+choose upstream servers that do not expose sensitive prompts.
+
+**Gap 3 — `resources/list` and `resources/subscribe`.** List filtering
+is low effort but low impact (Gap 2 is the more important discovery
+gap). Subscribe is high effort. Both should wait until Gap 1 is shipped
+and the resource policy model is established.
+
+---
+
+## Impact on the MVP release checklist
+
+The checklist item **Stage 4 — Documentation review** should include a
+note that `prompts/get`, `resources/list`, and `resources/subscribe`
+are currently unguarded. Users who deploy eunox-mcp v0.1.0 against
+servers that expose resources or prompts should be aware of these limits.
+
+If Gap 5 and Gap 1 are resolved before tagging v0.1.0, the proxy's
+security posture for the two highest-severity gaps is adequate for an
+MVP. If they are not resolved, v0.1.0 should be released with an
+explicit advisory in the README noting that resource access and
+server-initiated sampling are not currently policy-controlled.


### PR DESCRIPTION
## What was wrong

The guide documented a fictional resource URI scheme (`api://crm/customers/*`, `storage://exports/*`, `db://warehouse/sales`) that has no relation to how the proxy actually works. The MCP protocol carries a **tool name string** in `tools/call` — there are no resource URIs, HTTP paths, or URL schemes. The `resource` field in the manifest is matched against that tool name string using `path.Match`.

The old Pattern A/B examples would never match any real MCP server because no MCP server names its tools `api://crm/customers/list`.

## What changed

### New § 2 — How enforcement works
Explains the two concrete things the proxy checks for every `tools/call`:
- **`resource`** → matched against the MCP tool name via `path.Match`
- **`actions`** → two modes:
  - Generic (`call`/`*`): permits any call for matched resources
  - Semantic (`read`, `write`, etc.): tool name resolved via HeuristicResolver chain (`get_*` → read, `create_*` → write, `delete_*` → delete, `run_*` → execute, etc.)

Includes a full table of the HeuristicResolver prefix mappings (sourced from `cmd/mcp/resolver.go`).

### Patterns A, B, C — rewritten with real tool names
- `api://crm/customers/*` → `get_*`, `list_*` (glob on tool name prefix)
- `api://crm/customers/*/notes` (write) → `add_customer_note` (exact tool name)
- `api://forecasting/predict` → `run_forecast`

### § 4 (resource pattern reference) — rewritten
Table now shows actual tool-name matching (`get_customer`, `get_*`, `*_report`) instead of fictional URIs.

### § 5 (conditions cookbook) — rewritten
Resources use real tool names (`get_invoice`, `export_data`, `query_sales`, `send_email`). Also adds `allowedOperations` to the cookbook — it was missing despite being used in the demo.

### Removed broken link
`enforcement.md` does not exist. Removed the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)