### PR TITLE
feat: implement Fix 2 (validate --live) and Fix 4 (init) from contract-drift doc

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -103,7 +103,9 @@ jobs:
 
       - name: Run manifest-only integration tests
         run: make -C demo ci-test
-        # Starts mock-mcp-server + eunox-mcp (Keycloak skipped via --scale 0).
+        # Starts mock-mcp-server + eunox-mcp.
+        # Keycloak is excluded entirely (profiles: ["jwt"]) so its image is
+        # never pulled and quay.io availability cannot affect this job.
         # CI=true is set by GitHub Actions; color output is suppressed.
 
       - name: Dump container logs on failure
@@ -135,9 +137,17 @@ jobs:
           docker compose version
           jq --version
 
+      - name: Pre-pull Keycloak image (retry on quay.io transient failures)
+        run: |
+          for i in 1 2 3; do
+            docker pull quay.io/keycloak/keycloak:26.0 && break
+            echo "Pull attempt $i failed. Retrying in 20s..."
+            sleep 20
+          done
+
       - name: Run JWT-mode integration tests
         run: make -C demo ci-test-jwt
-        # Starts mock-mcp-server + Keycloak + eunox-mcp (JWT overlay).
+        # Starts mock-mcp-server + Keycloak (--profile jwt) + eunox-mcp (JWT overlay).
         # --wait blocks until Keycloak's healthcheck passes before running tests.
 
       - name: Dump container logs on failure

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -137,13 +137,33 @@ jobs:
           docker compose version
           jq --version
 
-      - name: Pre-pull Keycloak image (retry on quay.io transient failures)
+      # Cache the Keycloak image as a tar so quay.io outages do not block CI.
+      # The cache key includes the image tag; bump the suffix (v1→v2) to force
+      # a fresh pull after a Keycloak upgrade.
+      - name: Cache Keycloak image
+        id: cache-keycloak
+        uses: actions/cache@v4
+        with:
+          path: /tmp/keycloak-image
+          key: keycloak-image-26.0-v1
+
+      - name: Restore or pull Keycloak image
         run: |
-          for i in 1 2 3; do
-            docker pull quay.io/keycloak/keycloak:26.0 && break
-            echo "Pull attempt $i failed. Retrying in 20s..."
-            sleep 20
-          done
+          if [ "${{ steps.cache-keycloak.outputs.cache-hit }}" = "true" ]; then
+            echo "Loading Keycloak image from Actions cache..."
+            docker load --input /tmp/keycloak-image/keycloak.tar
+          else
+            echo "Pulling Keycloak from quay.io (up to 6 attempts, 30 s apart)..."
+            for i in $(seq 1 6); do
+              docker pull quay.io/keycloak/keycloak:26.0 && break
+              echo "Attempt $i/6 failed."
+              [ "$i" -eq 6 ] && { echo "All pull attempts exhausted."; exit 1; }
+              sleep 30
+            done
+            mkdir -p /tmp/keycloak-image
+            docker save quay.io/keycloak/keycloak:26.0 \
+              --output /tmp/keycloak-image/keycloak.tar
+          fi
 
       - name: Run JWT-mode integration tests
         run: make -C demo ci-test-jwt

--- a/cmd/mcp/drift.go
+++ b/cmd/mcp/drift.go
@@ -43,23 +43,26 @@ const (
 	DriftFM2 DriftKind = "fm2"
 	// DriftFM3 — condition argument not found in live inputSchema (FM-3, silent bypass risk).
 	DriftFM3 DriftKind = "fm3"
+	// DriftFM4 — live server version does not satisfy the manifest's serverVersion pin (FM-4).
+	DriftFM4 DriftKind = "fm4"
 	// DriftUncovered — upstream tool has no manifest entry (informational; denied by default).
 	DriftUncovered DriftKind = "uncovered"
 )
 
 // DriftWarning is one finding produced by CheckManifestDrift.
 type DriftWarning struct {
-	Kind     DriftKind
-	Tool     string // upstream tool name (empty for FM-2)
-	Resource string // manifest resource pattern (empty for uncovered)
-	Argument string // condition argument name (FM-3 only)
+	Kind          DriftKind
+	Tool          string // upstream tool name (empty for FM-2, FM-4)
+	Resource      string // manifest resource pattern (empty for uncovered); version constraint for FM-4
+	Argument      string // condition argument name (FM-3 only)
+	VersionActual string // actual server version reported in initialize (FM-4 only)
 }
 
 // IsFatal reports whether this finding should abort session establishment
-// when --strict-drift is set.  FM-1 and FM-2 are fatal; FM-3 and uncovered
-// are advisory.
+// when --strict-drift is set.  FM-1, FM-2, and FM-4 are fatal; FM-3 and
+// uncovered are advisory.
 func (w DriftWarning) IsFatal() bool {
-	return w.Kind == DriftFM1 || w.Kind == DriftFM2
+	return w.Kind == DriftFM1 || w.Kind == DriftFM2 || w.Kind == DriftFM4
 }
 
 // severity returns the log-level label for this finding.
@@ -88,6 +91,15 @@ func (w DriftWarning) LogLine() string {
 			`[eunox-mcp] %s drift=fm3 resource=%q tool=%q argument=%q — condition argument not in live inputSchema; condition may not enforce if argument was renamed`,
 			w.severity(), w.Resource, w.Tool, w.Argument,
 		)
+	case DriftFM4:
+		actual := w.VersionActual
+		if actual == "" {
+			actual = "(unknown)"
+		}
+		return fmt.Sprintf(
+			`[eunox-mcp] %s drift=fm4 serverVersion=%q actual=%q — server version does not satisfy manifest pin; server may have been updated`,
+			w.severity(), w.Resource, actual,
+		)
 	case DriftUncovered:
 		return fmt.Sprintf(
 			`[eunox-mcp] %s drift=uncovered tool=%q — not covered by manifest; all calls will be denied`,
@@ -99,15 +111,29 @@ func (w DriftWarning) LogLine() string {
 }
 
 // CheckManifestDrift compares the manifest against the live upstream tool list
-// and returns all drift findings.  Returns nil when no issues are found.
+// and server version, and returns all drift findings.  Returns nil when no
+// issues are found.
+//
+// serverVersion is the version string from the upstream initialize response
+// (empty string if the upstream did not report one).
 //
 // This function is pure (no I/O) and safe to call from tests.
-func CheckManifestDrift(manifest *LocalManifest, tools []UpstreamTool) []DriftWarning {
+func CheckManifestDrift(manifest *LocalManifest, tools []UpstreamTool, serverVersion string) []DriftWarning {
 	if manifest == nil {
 		return nil
 	}
 
 	var warnings []DriftWarning
+
+	// ── FM-4: server version pin ──────────────────────────────────────────────
+
+	if manifest.ServerVersion != "" && !matchServerVersion(manifest.ServerVersion, serverVersion) {
+		warnings = append(warnings, DriftWarning{
+			Kind:          DriftFM4,
+			Resource:      manifest.ServerVersion,
+			VersionActual: serverVersion,
+		})
+	}
 
 	// ── FM-1 and uncovered: iterate each live tool against the manifest ────────
 
@@ -371,7 +397,7 @@ func runHTTPDriftCheck(ctx context.Context, sess *httpSession, manifest *LocalMa
 		fmt.Fprintf(os.Stderr, "[eunox-mcp] WARN drift check skipped (tools/list unavailable): %v\n", err)
 		return nil
 	}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, sess.upstreamServerVersion)
 	emitDriftWarnings(warnings)
 	if strict && hasFatalDrift(warnings) {
 		return fmt.Errorf("startup aborted by --strict-drift: manifest drift detected (see warnings above)")
@@ -389,10 +415,39 @@ func runStdioDriftCheck(proxy *StdioProxy, manifest *LocalManifest, strict bool)
 		fmt.Fprintf(os.Stderr, "[eunox-mcp] WARN drift check skipped (tools/list unavailable): %v\n", err)
 		return nil
 	}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, proxy.upstreamServerVersion)
 	emitDriftWarnings(warnings)
 	if strict && hasFatalDrift(warnings) {
 		return fmt.Errorf("startup aborted by --strict-drift: manifest drift detected (see warnings above)")
 	}
 	return nil
+}
+
+// matchServerVersion reports whether actual satisfies constraint.
+// constraint is a dot-separated version string where any component may be "*"
+// to wildcard that position and everything beyond it:
+//
+//	"1.2.3"  — exact match
+//	"1.2.*"  — major 1, minor 2, any patch
+//	"1.*"    — major 1, any minor and patch
+//	"*"      — any version
+//
+// An empty constraint always matches (no pinning configured).
+func matchServerVersion(constraint, actual string) bool {
+	if constraint == "" {
+		return true
+	}
+	cParts := strings.Split(constraint, ".")
+	aParts := strings.Split(actual, ".")
+	for i, c := range cParts {
+		if c == "*" {
+			return true
+		}
+		if i >= len(aParts) || aParts[i] != c {
+			return false
+		}
+	}
+	// All constraint parts matched; actual must have the same number of parts
+	// so that "1.2.3" does not match "1.2.3.4".
+	return len(aParts) == len(cParts)
 }

--- a/cmd/mcp/drift_test.go
+++ b/cmd/mcp/drift_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCheckManifestDrift_NilManifest(t *testing.T) {
 	tools := []UpstreamTool{{Name: "read_file"}}
-	if got := CheckManifestDrift(nil, tools); got != nil {
+	if got := CheckManifestDrift(nil, tools, ""); got != nil {
 		t.Errorf("nil manifest: want nil, got %v", got)
 	}
 }
@@ -27,7 +27,7 @@ func TestCheckManifestDrift_EmptyTools(t *testing.T) {
 	manifest := manifestWith(
 		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
 	)
-	warnings := CheckManifestDrift(manifest, nil)
+	warnings := CheckManifestDrift(manifest, nil, "")
 	// read_file has no live tool → FM-2
 	if !hasKind(warnings, DriftFM2) {
 		t.Error("expected FM-2 warning for dead manifest entry, got none")
@@ -41,7 +41,7 @@ func TestCheckManifestDrift_FM1_GlobMatch(t *testing.T) {
 		capability.Constraint{Resource: "delete_*", Actions: []string{"call"}},
 	)
 	tools := []UpstreamTool{{Name: "delete_all_records"}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 
 	fm1 := findKind(warnings, DriftFM1)
 	if fm1 == nil {
@@ -63,7 +63,7 @@ func TestCheckManifestDrift_FM1_ExactMatchNotFlagged(t *testing.T) {
 		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
 	)
 	tools := []UpstreamTool{{Name: "read_file"}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	if hasKind(warnings, DriftFM1) {
 		t.Error("exact manifest match must NOT produce FM-1 warning")
 	}
@@ -78,7 +78,7 @@ func TestCheckManifestDrift_FM1_MultipleGlobMatches(t *testing.T) {
 		{Name: "get_invoice"},
 		{Name: "get_report"},
 	}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	fm1s := findAllKind(warnings, DriftFM1)
 	if len(fm1s) != 3 {
 		t.Errorf("expected 3 FM-1 warnings (one per glob-matched tool), got %d", len(fm1s))
@@ -96,7 +96,7 @@ func TestCheckManifestDrift_FM1_ExactOverridesGlob(t *testing.T) {
 		{Name: "get_customer"},
 		{Name: "get_invoice"},
 	}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	fm1s := findAllKind(warnings, DriftFM1)
 	// Only get_invoice should fire; get_customer is exact-matched.
 	if len(fm1s) != 1 {
@@ -125,7 +125,7 @@ func TestCheckManifestDrift_FM1_WildcardPatterns(t *testing.T) {
 				capability.Constraint{Resource: tc.resource, Actions: []string{"call"}},
 			)
 			tools := []UpstreamTool{{Name: tc.tool}}
-			warnings := CheckManifestDrift(manifest, tools)
+			warnings := CheckManifestDrift(manifest, tools, "")
 			got := hasKind(warnings, DriftFM1)
 			if got != tc.wantFM1 {
 				t.Errorf("FM-1 for resource=%q tool=%q: want %v, got %v", tc.resource, tc.tool, tc.wantFM1, got)
@@ -142,7 +142,7 @@ func TestCheckManifestDrift_FM2_DeadEntry(t *testing.T) {
 	)
 	// Upstream has been renamed; query_db no longer exists.
 	tools := []UpstreamTool{{Name: "execute_query"}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 
 	fm2 := findKind(warnings, DriftFM2)
 	if fm2 == nil {
@@ -162,7 +162,7 @@ func TestCheckManifestDrift_FM2_GlobWithNoMatches(t *testing.T) {
 	)
 	// No tool starts with "legacy_".
 	tools := []UpstreamTool{{Name: "read_file"}, {Name: "write_file"}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	if !hasKind(warnings, DriftFM2) {
 		t.Error("expected FM-2 for glob entry with no live matches")
 	}
@@ -173,7 +173,7 @@ func TestCheckManifestDrift_FM2_GlobWithMatchesNoFM2(t *testing.T) {
 		capability.Constraint{Resource: "get_*", Actions: []string{"call"}},
 	)
 	tools := []UpstreamTool{{Name: "get_customer"}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	if hasKind(warnings, DriftFM2) {
 		t.Error("FM-2 must not fire when the glob has at least one live match")
 	}
@@ -186,7 +186,7 @@ func TestCheckManifestDrift_FM2_MultipleDeadEntries(t *testing.T) {
 		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
 	)
 	tools := []UpstreamTool{{Name: "read_file"}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	fm2s := findAllKind(warnings, DriftFM2)
 	if len(fm2s) != 2 {
 		t.Errorf("expected 2 FM-2 warnings (old_read, old_write), got %d", len(fm2s))
@@ -215,7 +215,7 @@ func TestCheckManifestDrift_FM3_ArgumentMissing(t *testing.T) {
 			},
 		},
 	}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 
 	fm3 := findKind(warnings, DriftFM3)
 	if fm3 == nil {
@@ -251,7 +251,7 @@ func TestCheckManifestDrift_FM3_ArgumentPresent(t *testing.T) {
 			},
 		},
 	}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	if hasKind(warnings, DriftFM3) {
 		t.Error("FM-3 must not fire when argument exists in live schema")
 	}
@@ -269,7 +269,7 @@ func TestCheckManifestDrift_FM3_NoSchema(t *testing.T) {
 	)
 	// Upstream tool has no inputSchema.
 	tools := []UpstreamTool{{Name: "read_file"}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	if hasKind(warnings, DriftFM3) {
 		t.Error("FM-3 must not fire when the live tool has no inputSchema")
 	}
@@ -296,7 +296,7 @@ func TestCheckManifestDrift_FM3_MultipleConditionTypes(t *testing.T) {
 			},
 		},
 	}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	fm3s := findAllKind(warnings, DriftFM3)
 	if len(fm3s) != 2 {
 		t.Errorf("expected 2 FM-3 warnings (sql, db_name), got %d: %v", len(fm3s), fm3s)
@@ -322,7 +322,7 @@ func TestCheckManifestDrift_FM3_DeduplicatesArgNames(t *testing.T) {
 			"properties": map[string]interface{}{"file_path": map[string]interface{}{}},
 		},
 	}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	fm3s := findAllKind(warnings, DriftFM3)
 	if len(fm3s) != 1 {
 		t.Errorf("expected exactly 1 FM-3 for deduplicated argument, got %d", len(fm3s))
@@ -347,7 +347,7 @@ func TestCheckManifestDrift_FM3_EmptyArgumentSkipped(t *testing.T) {
 			"properties": map[string]interface{}{"query": map[string]interface{}{}},
 		},
 	}}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	if hasKind(warnings, DriftFM3) {
 		t.Error("FM-3 must not fire for empty argument (scan-all-args mode)")
 	}
@@ -364,7 +364,7 @@ func TestCheckManifestDrift_Uncovered(t *testing.T) {
 		{Name: "write_file"},
 		{Name: "summarise_text"},
 	}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	uncovered := findAllKind(warnings, DriftUncovered)
 	if len(uncovered) != 2 {
 		t.Errorf("expected 2 uncovered tools, got %d: %v", len(uncovered), uncovered)
@@ -387,7 +387,7 @@ func TestCheckManifestDrift_NoFindings(t *testing.T) {
 		{Name: "read_file"},
 		{Name: "query_db"},
 	}
-	warnings := CheckManifestDrift(manifest, tools)
+	warnings := CheckManifestDrift(manifest, tools, "")
 	for _, w := range warnings {
 		if w.IsFatal() {
 			t.Errorf("clean manifest: unexpected fatal warning %+v", w)
@@ -396,6 +396,184 @@ func TestCheckManifestDrift_NoFindings(t *testing.T) {
 	// FM-1 and FM-2 must be absent.
 	if hasKind(warnings, DriftFM1) || hasKind(warnings, DriftFM2) {
 		t.Error("clean manifest: unexpected FM-1 or FM-2 warnings")
+	}
+}
+
+// ── FM-4: server version pin ──────────────────────────────────────────────────
+
+func TestCheckManifestDrift_FM4_VersionMismatch(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.3"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	warnings := CheckManifestDrift(manifest, tools, "1.2.4")
+
+	fm4 := findKind(warnings, DriftFM4)
+	if fm4 == nil {
+		t.Fatal("expected FM-4 warning for version mismatch, got none")
+	}
+	if fm4.Resource != "1.2.3" {
+		t.Errorf("FM-4 Resource (constraint): want 1.2.3, got %q", fm4.Resource)
+	}
+	if fm4.VersionActual != "1.2.4" {
+		t.Errorf("FM-4 VersionActual: want 1.2.4, got %q", fm4.VersionActual)
+	}
+	if !fm4.IsFatal() {
+		t.Error("FM-4 must be fatal")
+	}
+}
+
+func TestCheckManifestDrift_FM4_VersionMatch(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.3"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	warnings := CheckManifestDrift(manifest, tools, "1.2.3")
+
+	if hasKind(warnings, DriftFM4) {
+		t.Error("FM-4 must not fire when version matches exactly")
+	}
+}
+
+func TestCheckManifestDrift_FM4_WildcardPatch(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.*"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	// Any patch of 1.2 should match.
+	for _, actual := range []string{"1.2.0", "1.2.5", "1.2.99"} {
+		t.Run(actual, func(t *testing.T) {
+			warnings := CheckManifestDrift(manifest, tools, actual)
+			if hasKind(warnings, DriftFM4) {
+				t.Errorf("FM-4 must not fire for %q against pin %q", actual, manifest.ServerVersion)
+			}
+		})
+	}
+
+	// Different minor should fire FM-4.
+	warnings := CheckManifestDrift(manifest, tools, "1.3.0")
+	if !hasKind(warnings, DriftFM4) {
+		t.Error("FM-4 must fire for 1.3.0 against pin 1.2.*")
+	}
+}
+
+func TestCheckManifestDrift_FM4_WildcardMinor(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.*"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	for _, actual := range []string{"1.0.0", "1.2.3", "1.99.0"} {
+		t.Run(actual, func(t *testing.T) {
+			warnings := CheckManifestDrift(manifest, tools, actual)
+			if hasKind(warnings, DriftFM4) {
+				t.Errorf("FM-4 must not fire for %q against pin %q", actual, manifest.ServerVersion)
+			}
+		})
+	}
+
+	warnings := CheckManifestDrift(manifest, tools, "2.0.0")
+	if !hasKind(warnings, DriftFM4) {
+		t.Error("FM-4 must fire for 2.0.0 against pin 1.*")
+	}
+}
+
+func TestCheckManifestDrift_FM4_UnknownServerVersion(t *testing.T) {
+	// If the server doesn't report a version, it can't satisfy any pin.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.3"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	warnings := CheckManifestDrift(manifest, tools, "")
+	if !hasKind(warnings, DriftFM4) {
+		t.Error("FM-4 must fire when server version is absent and a pin is configured")
+	}
+	fm4 := findKind(warnings, DriftFM4)
+	if fm4 != nil && fm4.VersionActual != "" {
+		t.Errorf("FM-4 VersionActual should be empty for absent version, got %q", fm4.VersionActual)
+	}
+}
+
+func TestCheckManifestDrift_FM4_NoPinConfigured(t *testing.T) {
+	// No serverVersion in manifest — FM-4 must never fire.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	for _, actual := range []string{"", "1.0.0", "99.0.0"} {
+		warnings := CheckManifestDrift(manifest, tools, actual)
+		if hasKind(warnings, DriftFM4) {
+			t.Errorf("FM-4 must not fire when no serverVersion is configured (actual=%q)", actual)
+		}
+	}
+}
+
+func TestCheckManifestDrift_FM4_LogLine(t *testing.T) {
+	w := DriftWarning{Kind: DriftFM4, Resource: "1.2.*", VersionActual: "1.3.0"}
+	line := w.LogLine()
+	for _, want := range []string{"WARN", "fm4", "1.2.*", "1.3.0"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("FM-4 LogLine missing %q: %s", want, line)
+		}
+	}
+}
+
+func TestCheckManifestDrift_FM4_UnknownActualInLogLine(t *testing.T) {
+	w := DriftWarning{Kind: DriftFM4, Resource: "1.2.3", VersionActual: ""}
+	if !strings.Contains(w.LogLine(), "(unknown)") {
+		t.Error("FM-4 LogLine should say (unknown) when VersionActual is empty")
+	}
+}
+
+// ── matchServerVersion ────────────────────────────────────────────────────────
+
+func TestMatchServerVersion(t *testing.T) {
+	cases := []struct {
+		constraint string
+		actual     string
+		want       bool
+	}{
+		// Exact match
+		{"1.2.3", "1.2.3", true},
+		{"1.2.3", "1.2.4", false},
+		{"1.2.3", "1.2.3.0", false}, // extra component
+		// Patch wildcard
+		{"1.2.*", "1.2.0", true},
+		{"1.2.*", "1.2.99", true},
+		{"1.2.*", "1.3.0", false},
+		{"1.2.*", "2.2.0", false},
+		// Minor+patch wildcard
+		{"1.*", "1.0.0", true},
+		{"1.*", "1.99.42", true},
+		{"1.*", "2.0.0", false},
+		// Any-version wildcard
+		{"*", "1.2.3", true},
+		{"*", "", true},
+		{"*", "99.0.0", true},
+		// Empty constraint — always matches
+		{"", "1.2.3", true},
+		{"", "", true},
+		// Empty actual with non-empty constraint
+		{"1.2.3", "", false},
+		{"1.*", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.constraint+"/"+tc.actual, func(t *testing.T) {
+			got := matchServerVersion(tc.constraint, tc.actual)
+			if got != tc.want {
+				t.Errorf("matchServerVersion(%q, %q) = %v, want %v", tc.constraint, tc.actual, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/mcp/http.go
+++ b/cmd/mcp/http.go
@@ -173,8 +173,9 @@ type httpSession struct {
 	pendingMu sync.Mutex
 	pending   map[string]chan rpcMsg
 
-	upstreamCaps map[string]interface{}
-	idCounter    int64
+	upstreamCaps          map[string]interface{}
+	upstreamServerVersion string // version from the upstream initialize serverInfo response
+	idCounter             int64
 
 	notifMu   sync.Mutex
 	notifSubs []chan rpcMsg

--- a/cmd/mcp/http_remote.go
+++ b/cmd/mcp/http_remote.go
@@ -148,11 +148,14 @@ func (s *httpSession) initRemoteUpstream(ctx context.Context) error {
 	// Capture the upstream session ID from the response header.
 	s.upstreamSessID = respHdr.Get(sessionHeader)
 
-	// Extract server capabilities.
+	// Extract server capabilities and version.
 	if respMsg.Result != nil {
 		var result mcpInitResult
 		if json.Unmarshal(respMsg.Result, &result) == nil {
 			s.upstreamCaps = result.Capabilities
+			if sv, ok := result.ServerInfo["version"].(string); ok {
+				s.upstreamServerVersion = sv
+			}
 		}
 	}
 

--- a/cmd/mcp/init_manifest.go
+++ b/cmd/mcp/init_manifest.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Eunolabs, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Starter manifest generator for the init subcommand (Fix 4).
+//
+// generateInitManifestYAML produces a YAML manifest where every tool is
+// commented out.  Operators uncomment and add conditions only for tools the
+// agent genuinely needs.  Re-running init after a server update and diffing
+// against the current manifest surfaces additions and removals.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// generateInitManifestYAML returns a deny-all starter YAML manifest for the
+// given tool list.  Every tool entry is commented out; the capabilities section
+// is valid but empty until the operator uncomments individual entries.
+func generateInitManifestYAML(tools []UpstreamTool, manifestName string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "name: %q\n", manifestName)
+	sb.WriteString("version: \"1.0.0\"\n\n")
+
+	if len(tools) == 0 {
+		sb.WriteString("capabilities: [] # no tools found on upstream\n")
+		return sb.String()
+	}
+
+	sb.WriteString("capabilities:\n")
+	sb.WriteString("  # REVIEW: uncomment and add conditions before enabling each tool.\n")
+
+	for i, tool := range tools {
+		if i > 0 {
+			// Blank comment line separates entries for readability.
+			sb.WriteString("  #\n")
+		}
+		for _, line := range toolEntryYAMLLines(tool) {
+			sb.WriteString("  # ")
+			sb.WriteString(line)
+			sb.WriteString("\n")
+		}
+	}
+
+	return sb.String()
+}
+
+// toolEntryYAMLLines returns the unindented YAML content lines for one tool
+// entry.  Each line is prefixed with "  # " by the caller.
+func toolEntryYAMLLines(tool UpstreamTool) []string {
+	lines := []string{
+		fmt.Sprintf("- resource: %s", tool.Name),
+		"  actions: [call]",
+	}
+	if schemaLines := argumentSchemaYAML(tool.InputSchema); len(schemaLines) > 0 {
+		lines = append(lines, "  argumentSchema:")
+		lines = append(lines, schemaLines...)
+	}
+	return lines
+}
+
+// argumentSchemaYAML returns indented YAML lines for the argumentSchema block,
+// or nil when the schema has no properties to emit.
+func argumentSchemaYAML(schema map[string]interface{}) []string {
+	props, ok := schemaProperties(schema)
+	if !ok {
+		return nil
+	}
+
+	lines := []string{
+		"    type: object",
+		"    properties:",
+	}
+
+	for _, name := range sortedMapKeys(props) {
+		typeStr := "string"
+		if propMap, ok := props[name].(map[string]interface{}); ok {
+			if t, ok := propMap["type"].(string); ok && t != "" {
+				typeStr = t
+			}
+		}
+		lines = append(lines, fmt.Sprintf("      %s: { type: %s }", name, typeStr))
+	}
+
+	if reqRaw, ok := schema["required"].([]interface{}); ok && len(reqRaw) > 0 {
+		required := make([]string, 0, len(reqRaw))
+		for _, r := range reqRaw {
+			if s, ok := r.(string); ok {
+				required = append(required, s)
+			}
+		}
+		if len(required) > 0 {
+			lines = append(lines, fmt.Sprintf("    required: [%s]", strings.Join(required, ", ")))
+		}
+	}
+
+	return lines
+}
+
+// sortedMapKeys returns the keys of m in sorted order.
+func sortedMapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/mcp/init_manifest.go
+++ b/cmd/mcp/init_manifest.go
@@ -19,10 +19,21 @@ import (
 // generateInitManifestYAML returns a deny-all starter YAML manifest for the
 // given tool list.  Every tool entry is commented out; the capabilities section
 // is valid but empty until the operator uncomments individual entries.
-func generateInitManifestYAML(tools []UpstreamTool, manifestName string) string {
+// serverVersion is the version string from the upstream initialize response; if
+// non-empty it is added as a commented-out serverVersion field so the operator
+// can easily enable version pinning.
+func generateInitManifestYAML(tools []UpstreamTool, manifestName, serverVersion string) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "name: %q\n", manifestName)
-	sb.WriteString("version: \"1.0.0\"\n\n")
+	sb.WriteString("version: \"1.0.0\"\n")
+	if serverVersion != "" {
+		// Show both an exact pin and a wildcard suggestion so the operator can
+		// choose how strictly to pin.
+		wildcard := serverVersionWildcard(serverVersion)
+		fmt.Fprintf(&sb, "# serverVersion: %q  # uncomment to pin; use %q to allow patch updates\n",
+			serverVersion, wildcard)
+	}
+	sb.WriteString("\n")
 
 	if len(tools) == 0 {
 		sb.WriteString("capabilities: [] # no tools found on upstream\n")
@@ -97,6 +108,24 @@ func argumentSchemaYAML(schema map[string]interface{}) []string {
 	}
 
 	return lines
+}
+
+// serverVersionWildcard returns a "major.minor.*" suggestion from v, replacing
+// the patch component with a wildcard so operators can allow patch updates while
+// still pinning to a specific major.minor.
+// For single-part versions (e.g. "2") it returns "2.*".
+// For two-part versions (e.g. "1.2") it returns "1.2.*".
+func serverVersionWildcard(v string) string {
+	if v == "" {
+		return "*"
+	}
+	parts := strings.Split(v, ".")
+	switch len(parts) {
+	case 1:
+		return parts[0] + ".*"
+	default:
+		return parts[0] + "." + parts[1] + ".*"
+	}
 }
 
 // sortedMapKeys returns the keys of m in sorted order.

--- a/cmd/mcp/init_manifest_test.go
+++ b/cmd/mcp/init_manifest_test.go
@@ -11,7 +11,7 @@ import (
 // ─── generateInitManifestYAML ─────────────────────────────────────────────────
 
 func TestGenerateInitManifestYAML_Header(t *testing.T) {
-	yaml := generateInitManifestYAML(nil, "my-policy")
+	yaml := generateInitManifestYAML(nil, "my-policy", "")
 
 	if !strings.Contains(yaml, `name: "my-policy"`) {
 		t.Errorf("header: missing name field, got:\n%s", yaml)
@@ -22,7 +22,7 @@ func TestGenerateInitManifestYAML_Header(t *testing.T) {
 }
 
 func TestGenerateInitManifestYAML_EmptyTools(t *testing.T) {
-	yaml := generateInitManifestYAML(nil, "empty-manifest")
+	yaml := generateInitManifestYAML(nil, "empty-manifest", "")
 
 	if !strings.Contains(yaml, "capabilities:") {
 		t.Error("should contain capabilities:")
@@ -38,7 +38,7 @@ func TestGenerateInitManifestYAML_EmptyTools(t *testing.T) {
 
 func TestGenerateInitManifestYAML_ToolNoSchema(t *testing.T) {
 	tools := []UpstreamTool{{Name: "simple_tool"}}
-	yaml := generateInitManifestYAML(tools, "test")
+	yaml := generateInitManifestYAML(tools, "test", "")
 
 	if !strings.Contains(yaml, "# - resource: simple_tool") {
 		t.Errorf("should have commented-out resource entry, got:\n%s", yaml)
@@ -64,7 +64,7 @@ func TestGenerateInitManifestYAML_ToolWithSchema(t *testing.T) {
 			"required": []interface{}{"path"},
 		},
 	}}
-	yaml := generateInitManifestYAML(tools, "test")
+	yaml := generateInitManifestYAML(tools, "test", "")
 
 	for _, want := range []string{
 		"#   argumentSchema:",
@@ -91,7 +91,7 @@ func TestGenerateInitManifestYAML_ToolSchemaUnknownType(t *testing.T) {
 			},
 		},
 	}}
-	yaml := generateInitManifestYAML(tools, "test")
+	yaml := generateInitManifestYAML(tools, "test", "")
 
 	if !strings.Contains(yaml, "param: { type: string }") {
 		t.Errorf("unknown type should default to string, got:\n%s", yaml)
@@ -104,7 +104,7 @@ func TestGenerateInitManifestYAML_MultipleTools(t *testing.T) {
 		{Name: "tool_b"},
 		{Name: "tool_c"},
 	}
-	yaml := generateInitManifestYAML(tools, "test")
+	yaml := generateInitManifestYAML(tools, "test", "")
 
 	for _, name := range []string{"tool_a", "tool_b", "tool_c"} {
 		if !strings.Contains(yaml, "resource: "+name) {
@@ -120,7 +120,7 @@ func TestGenerateInitManifestYAML_MultipleTools(t *testing.T) {
 
 func TestGenerateInitManifestYAML_ReviewComment(t *testing.T) {
 	tools := []UpstreamTool{{Name: "some_tool"}}
-	yaml := generateInitManifestYAML(tools, "test")
+	yaml := generateInitManifestYAML(tools, "test", "")
 
 	if !strings.Contains(yaml, "REVIEW") {
 		t.Error("should contain the REVIEW guidance comment")
@@ -129,7 +129,7 @@ func TestGenerateInitManifestYAML_ReviewComment(t *testing.T) {
 
 func TestGenerateInitManifestYAML_AllEntriesCommentedOut(t *testing.T) {
 	tools := []UpstreamTool{{Name: "tool_a"}, {Name: "tool_b"}}
-	yaml := generateInitManifestYAML(tools, "test")
+	yaml := generateInitManifestYAML(tools, "test", "")
 
 	// Every line in the capabilities block must be a comment or blank.
 	// Scan the lines after "capabilities:".
@@ -267,6 +267,50 @@ func TestArgumentSchemaYAML_NoRequiredField(t *testing.T) {
 	for _, l := range lines {
 		if strings.Contains(l, "required") {
 			t.Errorf("should not emit required line when schema has no required field: %q", l)
+		}
+	}
+}
+
+// ─── server version in generated YAML ────────────────────────────────────────
+
+func TestGenerateInitManifestYAML_ServerVersionComment(t *testing.T) {
+	yaml := generateInitManifestYAML(nil, "test", "1.2.3")
+
+	// Should include a commented-out serverVersion line with the exact version.
+	if !strings.Contains(yaml, `# serverVersion: "1.2.3"`) {
+		t.Errorf("should include commented serverVersion with exact version, got:\n%s", yaml)
+	}
+	// Should also suggest the patch-wildcard form.
+	if !strings.Contains(yaml, "1.2.*") {
+		t.Errorf("should suggest patch wildcard 1.2.*, got:\n%s", yaml)
+	}
+}
+
+func TestGenerateInitManifestYAML_NoServerVersion(t *testing.T) {
+	yaml := generateInitManifestYAML(nil, "test", "")
+
+	if strings.Contains(yaml, "serverVersion") {
+		t.Errorf("should not emit serverVersion when none provided, got:\n%s", yaml)
+	}
+}
+
+// ─── serverVersionWildcard ────────────────────────────────────────────────────
+
+func TestServerVersionWildcard(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1.2.3", "1.2.*"},
+		{"1.2", "1.2.*"},
+		{"1", "1.*"},
+		{"", "*"},
+		{"1.2.3.4", "1.2.*"}, // only first two parts used
+	}
+	for _, tc := range cases {
+		got := serverVersionWildcard(tc.in)
+		if got != tc.want {
+			t.Errorf("serverVersionWildcard(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/cmd/mcp/init_manifest_test.go
+++ b/cmd/mcp/init_manifest_test.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Eunolabs, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// ─── generateInitManifestYAML ─────────────────────────────────────────────────
+
+func TestGenerateInitManifestYAML_Header(t *testing.T) {
+	yaml := generateInitManifestYAML(nil, "my-policy")
+
+	if !strings.Contains(yaml, `name: "my-policy"`) {
+		t.Errorf("header: missing name field, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, `version: "1.0.0"`) {
+		t.Errorf("header: missing version field, got:\n%s", yaml)
+	}
+}
+
+func TestGenerateInitManifestYAML_EmptyTools(t *testing.T) {
+	yaml := generateInitManifestYAML(nil, "empty-manifest")
+
+	if !strings.Contains(yaml, "capabilities:") {
+		t.Error("should contain capabilities:")
+	}
+	if !strings.Contains(yaml, "no tools") {
+		t.Errorf("should indicate no tools found, got:\n%s", yaml)
+	}
+	// Must not contain any resource entries.
+	if strings.Contains(yaml, "resource:") {
+		t.Error("empty tool list must not contain any resource entries")
+	}
+}
+
+func TestGenerateInitManifestYAML_ToolNoSchema(t *testing.T) {
+	tools := []UpstreamTool{{Name: "simple_tool"}}
+	yaml := generateInitManifestYAML(tools, "test")
+
+	if !strings.Contains(yaml, "# - resource: simple_tool") {
+		t.Errorf("should have commented-out resource entry, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "#   actions: [call]") {
+		t.Errorf("should have commented-out actions entry, got:\n%s", yaml)
+	}
+	// No argumentSchema when the tool has no inputSchema.
+	if strings.Contains(yaml, "argumentSchema") {
+		t.Error("should not emit argumentSchema for a tool with no inputSchema")
+	}
+}
+
+func TestGenerateInitManifestYAML_ToolWithSchema(t *testing.T) {
+	tools := []UpstreamTool{{
+		Name: "read_file",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path":     map[string]interface{}{"type": "string"},
+				"encoding": map[string]interface{}{"type": "string"},
+			},
+			"required": []interface{}{"path"},
+		},
+	}}
+	yaml := generateInitManifestYAML(tools, "test")
+
+	for _, want := range []string{
+		"#   argumentSchema:",
+		"#     type: object",
+		"#     properties:",
+		"#       encoding: { type: string }",
+		"#       path: { type: string }",
+		"#     required: [path]",
+	} {
+		if !strings.Contains(yaml, want) {
+			t.Errorf("missing expected line %q in:\n%s", want, yaml)
+		}
+	}
+}
+
+func TestGenerateInitManifestYAML_ToolSchemaUnknownType(t *testing.T) {
+	// Property without an explicit "type" field should default to "string".
+	tools := []UpstreamTool{{
+		Name: "tool_a",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"param": map[string]interface{}{}, // no "type" field
+			},
+		},
+	}}
+	yaml := generateInitManifestYAML(tools, "test")
+
+	if !strings.Contains(yaml, "param: { type: string }") {
+		t.Errorf("unknown type should default to string, got:\n%s", yaml)
+	}
+}
+
+func TestGenerateInitManifestYAML_MultipleTools(t *testing.T) {
+	tools := []UpstreamTool{
+		{Name: "tool_a"},
+		{Name: "tool_b"},
+		{Name: "tool_c"},
+	}
+	yaml := generateInitManifestYAML(tools, "test")
+
+	for _, name := range []string{"tool_a", "tool_b", "tool_c"} {
+		if !strings.Contains(yaml, "resource: "+name) {
+			t.Errorf("should contain resource entry for %s", name)
+		}
+	}
+
+	// There should be separator comment lines between tools.
+	if !strings.Contains(yaml, "  #\n") {
+		t.Error("should have blank separator comment lines between tool entries")
+	}
+}
+
+func TestGenerateInitManifestYAML_ReviewComment(t *testing.T) {
+	tools := []UpstreamTool{{Name: "some_tool"}}
+	yaml := generateInitManifestYAML(tools, "test")
+
+	if !strings.Contains(yaml, "REVIEW") {
+		t.Error("should contain the REVIEW guidance comment")
+	}
+}
+
+func TestGenerateInitManifestYAML_AllEntriesCommentedOut(t *testing.T) {
+	tools := []UpstreamTool{{Name: "tool_a"}, {Name: "tool_b"}}
+	yaml := generateInitManifestYAML(tools, "test")
+
+	// Every line in the capabilities block must be a comment or blank.
+	// Scan the lines after "capabilities:".
+	lines := strings.Split(yaml, "\n")
+	inCaps := false
+	for _, line := range lines {
+		if line == "capabilities:" {
+			inCaps = true
+			continue
+		}
+		if !inCaps {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "#") {
+			t.Errorf("non-comment line in capabilities block: %q", line)
+		}
+	}
+}
+
+// ─── toolEntryYAMLLines ──────────────────────────────────────────────────────
+
+func TestToolEntryYAMLLines_NoSchema(t *testing.T) {
+	lines := toolEntryYAMLLines(UpstreamTool{Name: "my_tool"})
+
+	if len(lines) != 2 {
+		t.Fatalf("no-schema tool: want 2 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "- resource: my_tool" {
+		t.Errorf("line[0]: want '- resource: my_tool', got %q", lines[0])
+	}
+	if lines[1] != "  actions: [call]" {
+		t.Errorf("line[1]: want '  actions: [call]', got %q", lines[1])
+	}
+}
+
+func TestToolEntryYAMLLines_WithSchema(t *testing.T) {
+	tool := UpstreamTool{
+		Name: "read_file",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{"type": "string"},
+			},
+			"required": []interface{}{"path"},
+		},
+	}
+	lines := toolEntryYAMLLines(tool)
+	joined := strings.Join(lines, "\n")
+
+	for _, want := range []string{
+		"- resource: read_file",
+		"  actions: [call]",
+		"  argumentSchema:",
+		"    type: object",
+		"    properties:",
+		"      path: { type: string }",
+		"    required: [path]",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("toolEntryYAMLLines: missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+// ─── argumentSchemaYAML ──────────────────────────────────────────────────────
+
+func TestArgumentSchemaYAML_Nil(t *testing.T) {
+	if lines := argumentSchemaYAML(nil); len(lines) != 0 {
+		t.Errorf("nil schema: want no lines, got %v", lines)
+	}
+}
+
+func TestArgumentSchemaYAML_EmptyProperties(t *testing.T) {
+	schema := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{},
+	}
+	if lines := argumentSchemaYAML(schema); len(lines) != 0 {
+		t.Errorf("empty properties: want no lines, got %v", lines)
+	}
+}
+
+func TestArgumentSchemaYAML_MultipleProperties_SortedAlphabetically(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"z_param": map[string]interface{}{"type": "string"},
+			"a_param": map[string]interface{}{"type": "integer"},
+			"m_param": map[string]interface{}{"type": "boolean"},
+		},
+	}
+	lines := argumentSchemaYAML(schema)
+	joined := strings.Join(lines, "\n")
+
+	aPos := strings.Index(joined, "a_param")
+	mPos := strings.Index(joined, "m_param")
+	zPos := strings.Index(joined, "z_param")
+	if aPos < 0 || mPos < 0 || zPos < 0 {
+		t.Fatal("all properties should appear in output")
+	}
+	if aPos >= mPos || mPos >= zPos {
+		t.Errorf("properties should be sorted alphabetically: a < m < z, got positions a=%d m=%d z=%d", aPos, mPos, zPos)
+	}
+}
+
+func TestArgumentSchemaYAML_RequiredFields(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"a": map[string]interface{}{"type": "string"},
+			"b": map[string]interface{}{"type": "string"},
+		},
+		"required": []interface{}{"a", "b"},
+	}
+	lines := argumentSchemaYAML(schema)
+	joined := strings.Join(lines, "\n")
+
+	if !strings.Contains(joined, "required: [a, b]") {
+		t.Errorf("should contain required: [a, b], got:\n%s", joined)
+	}
+}
+
+func TestArgumentSchemaYAML_NoRequiredField(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"param": map[string]interface{}{"type": "string"},
+		},
+	}
+	lines := argumentSchemaYAML(schema)
+	for _, l := range lines {
+		if strings.Contains(l, "required") {
+			t.Errorf("should not emit required line when schema has no required field: %q", l)
+		}
+	}
+}
+
+// ─── sortedMapKeys ───────────────────────────────────────────────────────────
+
+func TestSortedMapKeys(t *testing.T) {
+	m := map[string]interface{}{"z": 1, "a": 2, "m": 3}
+	got := sortedMapKeys(m)
+	want := []string{"a", "m", "z"}
+	if len(got) != len(want) {
+		t.Fatalf("sortedMapKeys: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sortedMapKeys[%d]: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/cmd/mcp/jsonrpc.go
+++ b/cmd/mcp/jsonrpc.go
@@ -81,7 +81,7 @@ func errorResponse(id *json.RawMessage, code int, message string) rpcMsg {
 }
 
 // notificationMsg builds a JSON-RPC 2.0 notification (no id).
-func notificationMsg(method string, params interface{}) (rpcMsg, error) {
+func notificationMsg(method string, params interface{}) (rpcMsg, error) { //nolint:unparam // method is always "notifications/initialized" today; kept generic for future use
 	var p json.RawMessage
 	if params != nil {
 		var err error

--- a/cmd/mcp/live_upstream.go
+++ b/cmd/mcp/live_upstream.go
@@ -17,12 +17,20 @@ import (
 	"strings"
 )
 
+// LiveUpstreamInfo holds the tool list and server metadata fetched from a
+// live MCP HTTP server during the validate --live and init handshake.
+type LiveUpstreamInfo struct {
+	Tools         []UpstreamTool
+	ServerVersion string // version field from initialize serverInfo; empty if absent
+}
+
 // fetchLiveTools connects to the remote MCP HTTP server at baseURL, performs
-// the initialize handshake, sends tools/list, and returns the live tool set.
+// the initialize handshake, sends tools/list, and returns the live tool set
+// together with the server version reported in the initialize response.
 //
 // baseURL is the server's base URL (e.g. "https://mcp.example.com"); "/mcp"
 // is appended automatically, matching the proxy convention.
-func fetchLiveTools(ctx context.Context, baseURL, authHeader string, tlsSkipVerify bool) ([]UpstreamTool, error) {
+func fetchLiveTools(ctx context.Context, baseURL, authHeader string, tlsSkipVerify bool) (LiveUpstreamInfo, error) {
 	client := buildUpstreamClient(tlsSkipVerify)
 	endpoint := strings.TrimRight(baseURL, "/") + "/mcp"
 
@@ -41,16 +49,27 @@ func fetchLiveTools(ctx context.Context, baseURL, authHeader string, tlsSkipVeri
 		Params:  initParams,
 	}, "", authHeader)
 	if err != nil {
-		return nil, fmt.Errorf("initialize: %w", err)
+		return LiveUpstreamInfo{}, fmt.Errorf("initialize: %w", err)
 	}
 	if initResp.Error != nil {
-		return nil, fmt.Errorf("initialize: server error %d: %s", initResp.Error.Code, initResp.Error.Message)
+		return LiveUpstreamInfo{}, fmt.Errorf("initialize: server error %d: %s", initResp.Error.Code, initResp.Error.Message)
 	}
 	sessID := respHdr.Get(sessionHeader)
 
+	// Extract the server version from the initialize result.
+	var serverVersion string
+	if initResp.Result != nil {
+		var initResult mcpInitResult
+		if json.Unmarshal(initResp.Result, &initResult) == nil {
+			if sv, ok := initResult.ServerInfo["version"].(string); ok {
+				serverVersion = sv
+			}
+		}
+	}
+
 	notif, _ := notificationMsg("notifications/initialized", nil)
 	if _, _, err := liveDoHTTP(ctx, client, endpoint, notif, sessID, authHeader); err != nil {
-		return nil, fmt.Errorf("notifications/initialized: %w", err)
+		return LiveUpstreamInfo{}, fmt.Errorf("notifications/initialized: %w", err)
 	}
 
 	listResp, _, err := liveDoHTTP(ctx, client, endpoint, rpcMsg{
@@ -59,12 +78,16 @@ func fetchLiveTools(ctx context.Context, baseURL, authHeader string, tlsSkipVeri
 		Method:  "tools/list",
 	}, sessID, authHeader)
 	if err != nil {
-		return nil, fmt.Errorf("tools/list: %w", err)
+		return LiveUpstreamInfo{}, fmt.Errorf("tools/list: %w", err)
 	}
 	if listResp.Error != nil {
-		return nil, fmt.Errorf("tools/list: server error %d: %s", listResp.Error.Code, listResp.Error.Message)
+		return LiveUpstreamInfo{}, fmt.Errorf("tools/list: server error %d: %s", listResp.Error.Code, listResp.Error.Message)
 	}
-	return parseToolsListResult(listResp.Result)
+	tools, err := parseToolsListResult(listResp.Result)
+	if err != nil {
+		return LiveUpstreamInfo{}, err
+	}
+	return LiveUpstreamInfo{Tools: tools, ServerVersion: serverVersion}, nil
 }
 
 // liveDoHTTP POSTs msg to endpoint, attaching sessID and authHeader as

--- a/cmd/mcp/live_upstream.go
+++ b/cmd/mcp/live_upstream.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Eunolabs, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Lightweight one-shot MCP client used by the validate --live and init
+// subcommands.  It is intentionally thin: no session management, no proxy
+// machinery — just the initialize handshake followed by tools/list.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// fetchLiveTools connects to the remote MCP HTTP server at baseURL, performs
+// the initialize handshake, sends tools/list, and returns the live tool set.
+//
+// baseURL is the server's base URL (e.g. "https://mcp.example.com"); "/mcp"
+// is appended automatically, matching the proxy convention.
+func fetchLiveTools(ctx context.Context, baseURL, authHeader string, tlsSkipVerify bool) ([]UpstreamTool, error) {
+	client := buildUpstreamClient(tlsSkipVerify)
+	endpoint := strings.TrimRight(baseURL, "/") + "/mcp"
+
+	initParams, _ := json.Marshal(map[string]interface{}{
+		"protocolVersion": mcpProtocolVersion,
+		"capabilities":    map[string]interface{}{},
+		"clientInfo": map[string]interface{}{
+			"name":    proxyName,
+			"version": proxyVersion,
+		},
+	})
+	initResp, respHdr, err := liveDoHTTP(ctx, client, endpoint, rpcMsg{
+		JSONRPC: "2.0",
+		ID:      rawJSON(`1`),
+		Method:  "initialize",
+		Params:  initParams,
+	}, "", authHeader)
+	if err != nil {
+		return nil, fmt.Errorf("initialize: %w", err)
+	}
+	if initResp.Error != nil {
+		return nil, fmt.Errorf("initialize: server error %d: %s", initResp.Error.Code, initResp.Error.Message)
+	}
+	sessID := respHdr.Get(sessionHeader)
+
+	notif, _ := notificationMsg("notifications/initialized", nil)
+	if _, _, err := liveDoHTTP(ctx, client, endpoint, notif, sessID, authHeader); err != nil {
+		return nil, fmt.Errorf("notifications/initialized: %w", err)
+	}
+
+	listResp, _, err := liveDoHTTP(ctx, client, endpoint, rpcMsg{
+		JSONRPC: "2.0",
+		ID:      rawJSON(`2`),
+		Method:  "tools/list",
+	}, sessID, authHeader)
+	if err != nil {
+		return nil, fmt.Errorf("tools/list: %w", err)
+	}
+	if listResp.Error != nil {
+		return nil, fmt.Errorf("tools/list: server error %d: %s", listResp.Error.Code, listResp.Error.Message)
+	}
+	return parseToolsListResult(listResp.Result)
+}
+
+// liveDoHTTP POSTs msg to endpoint, attaching sessID and authHeader as
+// request headers.  A 202 Accepted response (notifications) returns an empty
+// rpcMsg without error.
+func liveDoHTTP(ctx context.Context, client *http.Client, endpoint string, msg rpcMsg, sessID, authHeader string) (rpcMsg, http.Header, error) { //nolint:gocritic // hugeParam: rpcMsg intentionally passed by value
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return rpcMsg{}, nil, fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data)) //nolint:gosec // G107: endpoint constructed from user-specified --upstream-url flag
+	if err != nil {
+		return rpcMsg{}, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", ctJSON)
+	if sessID != "" {
+		req.Header.Set(sessionHeader, sessID)
+	}
+	if authHeader != "" {
+		parts := strings.SplitN(authHeader, ":", 2)
+		if len(parts) == 2 {
+			req.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return rpcMsg{}, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusAccepted {
+		return rpcMsg{}, resp.Header, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return rpcMsg{}, resp.Header, fmt.Errorf("upstream returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var result rpcMsg
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return rpcMsg{}, resp.Header, fmt.Errorf("decode response: %w", err)
+	}
+	return result, resp.Header, nil
+}

--- a/cmd/mcp/live_upstream_test.go
+++ b/cmd/mcp/live_upstream_test.go
@@ -33,10 +33,11 @@ func TestFetchLiveTools_HappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.StripPrefix("/mcp", fake))
 	t.Cleanup(srv.Close)
 
-	got, err := fetchLiveTools(context.Background(), srv.URL, "", false)
+	info, err := fetchLiveTools(context.Background(), srv.URL, "", false)
 	if err != nil {
 		t.Fatalf("fetchLiveTools: %v", err)
 	}
+	got := info.Tools
 	if len(got) != 2 {
 		t.Fatalf("expected 2 tools, got %d", len(got))
 	}
@@ -51,6 +52,10 @@ func TestFetchLiveTools_HappyPath(t *testing.T) {
 	}
 	if got[1].InputSchema != nil {
 		t.Error("got[1].InputSchema: want nil for tool without schema")
+	}
+	// Server version should be captured from initialize serverInfo.
+	if info.ServerVersion != "0.0.1" {
+		t.Errorf("ServerVersion: want 0.0.1, got %q", info.ServerVersion)
 	}
 
 	// Verify the handshake sequence: initialize → notifications/initialized → tools/list.
@@ -77,12 +82,12 @@ func TestFetchLiveTools_EmptyToolList(t *testing.T) {
 	srv := httptest.NewServer(http.StripPrefix("/mcp", fake))
 	t.Cleanup(srv.Close)
 
-	got, err := fetchLiveTools(context.Background(), srv.URL, "", false)
+	info, err := fetchLiveTools(context.Background(), srv.URL, "", false)
 	if err != nil {
 		t.Fatalf("fetchLiveTools: %v", err)
 	}
-	if len(got) != 0 {
-		t.Errorf("expected 0 tools, got %d", len(got))
+	if len(info.Tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(info.Tools))
 	}
 }
 
@@ -185,12 +190,12 @@ func TestFetchLiveTools_TLSSkipVerify(t *testing.T) {
 	}
 
 	// With skip-verify: should succeed despite the self-signed certificate.
-	got, err := fetchLiveTools(context.Background(), tlsSrv.URL, "", true)
+	info, err := fetchLiveTools(context.Background(), tlsSrv.URL, "", true)
 	if err != nil {
 		t.Fatalf("fetchLiveTools with skip-verify: %v", err)
 	}
-	if len(got) != 1 || got[0].Name != "tool_a" {
-		t.Errorf("skip-verify: expected [{tool_a}], got %v", got)
+	if len(info.Tools) != 1 || info.Tools[0].Name != "tool_a" {
+		t.Errorf("skip-verify: expected [{tool_a}], got %v", info.Tools)
 	}
 }
 
@@ -202,12 +207,12 @@ func TestFetchLiveTools_BaseURLTrailingSlash(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	// Pass URL with trailing slash.
-	got, err := fetchLiveTools(context.Background(), srv.URL+"/", "", false)
+	info, err := fetchLiveTools(context.Background(), srv.URL+"/", "", false)
 	if err != nil {
 		t.Fatalf("fetchLiveTools with trailing slash: %v", err)
 	}
-	if len(got) != 1 {
-		t.Errorf("expected 1 tool, got %d", len(got))
+	if len(info.Tools) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(info.Tools))
 	}
 }
 

--- a/cmd/mcp/live_upstream_test.go
+++ b/cmd/mcp/live_upstream_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Eunolabs, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestFetchLiveTools_HappyPath verifies the full handshake sequence and that
+// the returned tools match the upstream's tools/list response.
+func TestFetchLiveTools_HappyPath(t *testing.T) {
+	tools := []mcpToolEntry{
+		{
+			Name: "read_file",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"path": map[string]interface{}{"type": "string"},
+				},
+				"required": []interface{}{"path"},
+			},
+		},
+		{Name: "write_file"},
+	}
+	fake := newFakeUpstreamWithTools(tools)
+	srv := httptest.NewServer(http.StripPrefix("/mcp", fake))
+	t.Cleanup(srv.Close)
+
+	got, err := fetchLiveTools(context.Background(), srv.URL, "", false)
+	if err != nil {
+		t.Fatalf("fetchLiveTools: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(got))
+	}
+	if got[0].Name != "read_file" {
+		t.Errorf("got[0].Name: want read_file, got %q", got[0].Name)
+	}
+	if got[1].Name != "write_file" {
+		t.Errorf("got[1].Name: want write_file, got %q", got[1].Name)
+	}
+	if got[0].InputSchema == nil {
+		t.Error("got[0].InputSchema: want non-nil")
+	}
+	if got[1].InputSchema != nil {
+		t.Error("got[1].InputSchema: want nil for tool without schema")
+	}
+
+	// Verify the handshake sequence: initialize → notifications/initialized → tools/list.
+	reqs := fake.Received()
+	counts := make(map[string]int)
+	for _, r := range reqs {
+		counts[r.Body.Method]++
+	}
+	if counts["initialize"] != 1 {
+		t.Errorf("initialize count: want 1, got %d", counts["initialize"])
+	}
+	if counts["notifications/initialized"] != 1 {
+		t.Errorf("notifications/initialized count: want 1, got %d", counts["notifications/initialized"])
+	}
+	if counts["tools/list"] != 1 {
+		t.Errorf("tools/list count: want 1, got %d", counts["tools/list"])
+	}
+}
+
+// TestFetchLiveTools_EmptyToolList verifies that a tools/list with no tools
+// returns an empty slice without error.
+func TestFetchLiveTools_EmptyToolList(t *testing.T) {
+	fake := newFakeUpstreamWithTools(nil)
+	srv := httptest.NewServer(http.StripPrefix("/mcp", fake))
+	t.Cleanup(srv.Close)
+
+	got, err := fetchLiveTools(context.Background(), srv.URL, "", false)
+	if err != nil {
+		t.Fatalf("fetchLiveTools: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(got))
+	}
+}
+
+// TestFetchLiveTools_ConnectionRefused verifies that a refused connection
+// produces an error.
+func TestFetchLiveTools_ConnectionRefused(t *testing.T) {
+	_, err := fetchLiveTools(context.Background(), "http://127.0.0.1:1", "", false)
+	if err == nil {
+		t.Error("expected error for refused connection, got nil")
+	}
+}
+
+// TestFetchLiveTools_InitializeRPCError verifies that a JSON-RPC error in the
+// initialize response is surfaced as a Go error.
+func TestFetchLiveTools_InitializeRPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg rpcMsg
+		if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		resp := rpcMsg{
+			JSONRPC: "2.0",
+			ID:      msg.ID,
+			Error:   &rpcError{Code: -32000, Message: "server initialise rejected"},
+		}
+		w.Header().Set("Content-Type", ctJSON)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := fetchLiveTools(context.Background(), srv.URL, "", false)
+	if err == nil {
+		t.Fatal("expected error for RPC error response, got nil")
+	}
+	if !strings.Contains(err.Error(), "initialize") {
+		t.Errorf("error should mention 'initialize', got %q", err.Error())
+	}
+}
+
+// TestFetchLiveTools_UpstreamHTTP500 verifies that an HTTP 500 from the
+// upstream is surfaced as an error.
+func TestFetchLiveTools_UpstreamHTTP500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := fetchLiveTools(context.Background(), srv.URL, "", false)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500, got nil")
+	}
+}
+
+// TestFetchLiveTools_AuthHeaderForwarded verifies that --upstream-auth-header
+// is sent on every upstream request.
+func TestFetchLiveTools_AuthHeaderForwarded(t *testing.T) {
+	var mu sync.Mutex
+	captured := make(map[string]string) // method → Authorization value
+
+	fake := newFakeUpstreamWithTools([]mcpToolEntry{{Name: "tool_a"}})
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg rpcMsg
+		_ = json.NewDecoder(r.Body).Decode(&msg)
+		mu.Lock()
+		captured[msg.Method] = r.Header.Get("Authorization")
+		mu.Unlock()
+		// Replay the body for the real handler — body already consumed, so
+		// re-encode and serve.
+		fake.serveMsg(w, r, msg)
+	})
+	srv := httptest.NewServer(http.StripPrefix("/mcp", wrapped))
+	t.Cleanup(srv.Close)
+
+	const wantAuth = "Bearer live-test-token"
+	_, err := fetchLiveTools(context.Background(), srv.URL, "Authorization: "+wantAuth, false)
+	if err != nil {
+		t.Fatalf("fetchLiveTools: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for method, got := range captured {
+		if got != wantAuth {
+			t.Errorf("method %q: want Authorization=%q, got %q", method, wantAuth, got)
+		}
+	}
+}
+
+// TestFetchLiveTools_TLSSkipVerify verifies TLS behaviour in both modes.
+func TestFetchLiveTools_TLSSkipVerify(t *testing.T) {
+	fake := newFakeUpstreamWithTools([]mcpToolEntry{{Name: "tool_a"}})
+	tlsSrv := httptest.NewTLSServer(http.StripPrefix("/mcp", fake))
+	t.Cleanup(tlsSrv.Close)
+
+	// Without skip-verify: self-signed cert should cause an error.
+	_, err := fetchLiveTools(context.Background(), tlsSrv.URL, "", false)
+	if err == nil {
+		t.Error("expected TLS error without skip-verify, got nil")
+	}
+
+	// With skip-verify: should succeed despite the self-signed certificate.
+	got, err := fetchLiveTools(context.Background(), tlsSrv.URL, "", true)
+	if err != nil {
+		t.Fatalf("fetchLiveTools with skip-verify: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "tool_a" {
+		t.Errorf("skip-verify: expected [{tool_a}], got %v", got)
+	}
+}
+
+// TestFetchLiveTools_BaseURLTrailingSlash verifies that a trailing slash in the
+// base URL does not result in a double-slash in the MCP endpoint path.
+func TestFetchLiveTools_BaseURLTrailingSlash(t *testing.T) {
+	fake := newFakeUpstreamWithTools([]mcpToolEntry{{Name: "tool_a"}})
+	srv := httptest.NewServer(http.StripPrefix("/mcp", fake))
+	t.Cleanup(srv.Close)
+
+	// Pass URL with trailing slash.
+	got, err := fetchLiveTools(context.Background(), srv.URL+"/", "", false)
+	if err != nil {
+		t.Fatalf("fetchLiveTools with trailing slash: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(got))
+	}
+}
+
+// TestFetchLiveTools_ContextCancelled verifies that a pre-cancelled context
+// causes fetchLiveTools to return an error immediately.
+func TestFetchLiveTools_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	_, err := fetchLiveTools(ctx, "http://127.0.0.1:19999", "", false)
+	if err == nil {
+		t.Error("expected error for cancelled context, got nil")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// serveMsg allows fakeUpstreamWithTools to be used from a wrapper handler that
+// has already decoded the JSON body.  It re-dispatches based on Method.
+func (f *fakeUpstreamWithTools) serveMsg(w http.ResponseWriter, _ *http.Request, msg rpcMsg) {
+	f.mu.Lock()
+	f.received = append(f.received, fakeRequest{
+		Method: msg.Method,
+		Body:   msg,
+	})
+	f.mu.Unlock()
+
+	switch msg.Method {
+	case "initialize":
+		w.Header().Set(sessionHeader, "upstream-sess-1")
+		w.Header().Set("Content-Type", ctJSON)
+		result := mcpInitResult{
+			ProtocolVersion: mcpProtocolVersion,
+			Capabilities:    map[string]interface{}{"tools": map[string]interface{}{}},
+			ServerInfo:      map[string]interface{}{"name": "fake", "version": "0.0.1"},
+		}
+		resp, _ := successResponse(msg.ID, result)
+		_ = json.NewEncoder(w).Encode(resp)
+	case "notifications/initialized":
+		w.WriteHeader(http.StatusAccepted)
+	case "tools/list":
+		result := mcpToolsListResult{Tools: f.tools}
+		resp, _ := successResponse(msg.ID, result)
+		w.Header().Set("Content-Type", ctJSON)
+		_ = json.NewEncoder(w).Encode(resp)
+	default:
+		resp, _ := successResponse(msg.ID, map[string]interface{}{})
+		w.Header().Set("Content-Type", ctJSON)
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -9,7 +9,8 @@
 // Subcommands:
 //
 //	proxy          Start the proxy (stdio or HTTP transport).
-//	validate       Validate one or more manifest files and exit.
+//	validate       Validate manifest file(s); with --live, diff against a running upstream.
+//	init           Generate a deny-all starter manifest from a live upstream's tool list.
 //	kill           Send a kill-switch signal to a running HTTP proxy.
 //	validate-token Verify HMAC signatures in the audit log.
 //	stats          Print a denial histogram from the audit log.
@@ -60,6 +61,8 @@ func main() {
 		cmdProxy()
 	case "validate":
 		cmdValidate()
+	case "init":
+		cmdInit()
 	case "kill":
 		cmdKill()
 	case "validate-token":
@@ -85,9 +88,11 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, `eunox-mcp — MCP policy-enforcement proxy (%s)
 
 Usage:
-  eunox-mcp proxy   [flags] -- <command> [args...]        local subprocess upstream
-  eunox-mcp proxy   --transport http --upstream-url <url> remote MCP server
+  eunox-mcp proxy   [flags] -- <command> [args...]         local subprocess upstream
+  eunox-mcp proxy   --transport http --upstream-url <url>  remote MCP server
   eunox-mcp validate <manifest.yaml> [...]
+  eunox-mcp validate <manifest.yaml> --live --upstream-url <url>
+  eunox-mcp init    --upstream-url <url> [--output manifest.yaml]
   eunox-mcp kill    [--port N] [--host H] <session-id|all>
   eunox-mcp validate-token [flags]
   eunox-mcp stats   [flags]
@@ -96,6 +101,8 @@ Usage:
 Subcommands:
   proxy           Start the proxy (default: stdio transport).
   validate        Validate manifest file(s) and exit 0 on success.
+                  With --live: connect to a running upstream and report contract drift.
+  init            Generate a deny-all starter manifest from a live upstream's tool list.
   kill            Activate the kill switch on a running HTTP proxy.
   validate-token  Verify HMAC signatures in the local audit log.
   stats           Print a denial count histogram from the audit log.
@@ -412,8 +419,27 @@ Flags:
 func cmdValidate() {
 	fs := flag.NewFlagSet("validate", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprint(os.Stderr, "Usage: eunox-mcp validate <manifest.yaml> [...]\n\nValidate manifest file(s) and exit 0 on success.\n")
+		fmt.Fprint(os.Stderr, `Usage: eunox-mcp validate <manifest.yaml> [...] [--live flags]
+
+Validate manifest file(s).  Without --live, checks file syntax and exits.
+With --live, also connects to a running upstream MCP server and reports
+contract drift between the manifest and the live tool set.
+
+Exit codes with --live:
+  0  All manifest entries match live tools; no glob-matched tools detected.
+  1  Warnings or stale entries present (operator review required).
+  2  Connection or parse error.
+
+Flags:
+`)
+		fs.PrintDefaults()
 	}
+
+	live := fs.Bool("live", false, "Connect to a running upstream and report drift against the live tool set.")
+	upstreamURL := fs.String("upstream-url", "", "Base URL of the MCP HTTP server (required with --live).")
+	authHeader := fs.String("upstream-auth-header", "", `Header forwarded to the upstream in "Name: Value" format.`)
+	tlsSkipVerify := fs.Bool("upstream-tls-skip-verify", false, "Skip TLS certificate verification for the upstream (development only).")
+
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		os.Exit(1)
 	}
@@ -424,7 +450,9 @@ func cmdValidate() {
 		os.Exit(1)
 	}
 
+	// Syntax check (always runs).
 	ok := true
+	var manifests []*LocalManifest
 	for _, f := range files {
 		m, err := LoadManifest(f)
 		if err != nil {
@@ -432,11 +460,93 @@ func cmdValidate() {
 			ok = false
 		} else {
 			fmt.Printf("OK    %s  (name=%q version=%q capabilities=%d)\n", f, m.Name, m.Version, len(m.Capabilities))
+			manifests = append(manifests, m)
 		}
 	}
 	if !ok {
 		os.Exit(1)
 	}
+
+	if !*live {
+		return
+	}
+
+	// Live drift check.
+	if *upstreamURL == "" {
+		fmt.Fprintf(os.Stderr, "eunox-mcp validate: --upstream-url is required with --live\n")
+		os.Exit(1)
+	}
+
+	merged := MergeManifests(manifests)
+
+	fmt.Printf("\nConnecting to upstream (%s)...", *upstreamURL)
+	tools, err := fetchLiveTools(context.Background(), *upstreamURL, *authHeader, *tlsSkipVerify)
+	if err != nil {
+		fmt.Printf("  FAILED\n")
+		fmt.Fprintf(os.Stderr, "eunox-mcp validate: %v\n", err)
+		os.Exit(2)
+	}
+	fmt.Printf("  ok (%d tool(s))\n\n", len(tools))
+
+	code := runValidateLive(merged, tools, os.Stdout)
+	os.Exit(code)
+}
+
+// -----------------------------------------------------------------
+// init subcommand
+// -----------------------------------------------------------------
+
+func cmdInit() {
+	fs := flag.NewFlagSet("init", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `Usage: eunox-mcp init --upstream-url <url> [flags]
+
+Connect to a live MCP HTTP server and generate a deny-all starter manifest.
+Every tool is commented out — uncomment and add conditions only for tools
+the agent genuinely needs.  Re-running init after a server update and
+diffing against the current manifest surfaces additions and removals.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+
+	upstreamURL := fs.String("upstream-url", "", "Base URL of the MCP HTTP server (required).")
+	output := fs.String("output", "", "Path to write the generated manifest YAML (default: stdout).")
+	name := fs.String("name", "generated-manifest", "Value for the manifest name field.")
+	authHeader := fs.String("upstream-auth-header", "", `Header forwarded to the upstream in "Name: Value" format.`)
+	tlsSkipVerify := fs.Bool("upstream-tls-skip-verify", false, "Skip TLS certificate verification for the upstream (development only).")
+
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		os.Exit(1)
+	}
+
+	if *upstreamURL == "" {
+		fmt.Fprintf(os.Stderr, "eunox-mcp init: --upstream-url is required\n")
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "Fetching tool list from upstream...")
+	tools, err := fetchLiveTools(context.Background(), *upstreamURL, *authHeader, *tlsSkipVerify)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  FAILED\n")
+		fmt.Fprintf(os.Stderr, "eunox-mcp init: %v\n", err)
+		os.Exit(2)
+	}
+	fmt.Fprintf(os.Stderr, "  %d tool(s)\n\n", len(tools))
+
+	manifest := generateInitManifestYAML(tools, *name)
+
+	if *output == "" {
+		fmt.Print(manifest)
+		return
+	}
+
+	if err := os.WriteFile(*output, []byte(manifest), 0o600); err != nil { //nolint:gosec // G306: restrictive permissions are correct for a policy manifest
+		fmt.Fprintf(os.Stderr, "eunox-mcp init: writing %q: %v\n", *output, err)
+		os.Exit(2)
+	}
+	fmt.Fprintf(os.Stderr, "Generated %s\nReview and uncomment the capabilities you want to permit.\n", *output)
 }
 
 // -----------------------------------------------------------------

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -162,7 +162,7 @@ Flags:
 	dryRun := fs.Bool("dry-run", false, "Evaluate policies but do not block tool calls.\nDenials are logged to the audit trail with dry_run=true but the request is forwarded.\nUse for observation mode before production enforcement.")
 
 	// Drift detection flag.
-	strictDrift := fs.Bool("strict-drift", false, "Abort session startup when FM-1 (new glob-matched tool) or FM-2 (dead manifest entry) drift is detected.\nRequires --policy. Without this flag, drift findings are logged as warnings but sessions proceed.")
+	strictDrift := fs.Bool("strict-drift", false, "Abort session startup when FM-1 (new glob-matched tool), FM-2 (dead manifest entry), or FM-4 (server version mismatch) drift is detected.\nRequires --policy. Without this flag, drift findings are logged as warnings but sessions proceed.")
 
 	// Redis flags (optional — in-memory is used when absent).
 	redisAddr := fs.String("redis-addr", "", "Redis address (host:port) for persistent call-counter and kill-switch state.\nWhen set, state survives proxy restarts and is shared across instances.\nExample: --redis-addr localhost:6379")
@@ -480,15 +480,19 @@ Flags:
 	merged := MergeManifests(manifests)
 
 	fmt.Printf("\nConnecting to upstream (%s)...", *upstreamURL)
-	tools, err := fetchLiveTools(context.Background(), *upstreamURL, *authHeader, *tlsSkipVerify)
+	info, err := fetchLiveTools(context.Background(), *upstreamURL, *authHeader, *tlsSkipVerify)
 	if err != nil {
 		fmt.Printf("  FAILED\n")
 		fmt.Fprintf(os.Stderr, "eunox-mcp validate: %v\n", err)
 		os.Exit(2)
 	}
-	fmt.Printf("  ok (%d tool(s))\n\n", len(tools))
+	versionLabel := info.ServerVersion
+	if versionLabel == "" {
+		versionLabel = "unknown"
+	}
+	fmt.Printf("  ok (%d tool(s), server version: %s)\n\n", len(info.Tools), versionLabel)
 
-	code := runValidateLive(merged, tools, os.Stdout)
+	code := runValidateLive(merged, info.Tools, info.ServerVersion, os.Stdout)
 	os.Exit(code)
 }
 
@@ -527,15 +531,15 @@ Flags:
 	}
 
 	fmt.Fprintf(os.Stderr, "Fetching tool list from upstream...")
-	tools, err := fetchLiveTools(context.Background(), *upstreamURL, *authHeader, *tlsSkipVerify)
+	info, err := fetchLiveTools(context.Background(), *upstreamURL, *authHeader, *tlsSkipVerify)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "  FAILED\n")
 		fmt.Fprintf(os.Stderr, "eunox-mcp init: %v\n", err)
 		os.Exit(2)
 	}
-	fmt.Fprintf(os.Stderr, "  %d tool(s)\n\n", len(tools))
+	fmt.Fprintf(os.Stderr, "  %d tool(s)\n\n", len(info.Tools))
 
-	manifest := generateInitManifestYAML(tools, *name)
+	manifest := generateInitManifestYAML(info.Tools, *name, info.ServerVersion)
 
 	if *output == "" {
 		fmt.Print(manifest)

--- a/cmd/mcp/stdio.go
+++ b/cmd/mcp/stdio.go
@@ -78,6 +78,8 @@ type StdioProxy struct {
 
 	// upstreamCaps holds the server capabilities from the upstream initialize response.
 	upstreamCaps map[string]interface{}
+	// upstreamServerVersion holds the version string from the upstream serverInfo.
+	upstreamServerVersion string
 
 	// idCounter is used for the proxy→upstream initialize request ID.
 	idCounter int64
@@ -240,10 +242,13 @@ func (p *StdioProxy) initUpstream() error {
 			return fmt.Errorf("reading initialize response: %w", err)
 		}
 		if msg.isResponse() && msgKey(msg.ID) == msgKey(initID) {
-			// Extract server capabilities.
+			// Extract server capabilities and version.
 			var result mcpInitResult
 			if err := json.Unmarshal(msg.Result, &result); err == nil {
 				p.upstreamCaps = result.Capabilities
+				if sv, ok := result.ServerInfo["version"].(string); ok {
+					p.upstreamServerVersion = sv
+				}
 			}
 			break
 		}

--- a/cmd/mcp/validate_live.go
+++ b/cmd/mcp/validate_live.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Eunolabs, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Live drift report formatter for the validate --live subcommand (Fix 2).
+//
+// runValidateLive classifies every live tool against the manifest and renders
+// four sections:
+//
+//	COVERED              — tools matched by exact manifest entries (unambiguous)
+//	WARNINGS             — FM-1 glob-matched tools + FM-3 argument drift (review required)
+//	NOT COVERED          — tools with no manifest entry (denied by default)
+//	STALE MANIFEST ENTRIES — manifest entries with no live tool match (FM-2)
+//
+// Exit code 0 means the manifest is clean: every entry matches a live tool and
+// no live tool is matched only via a glob.  Exit code 1 means FM-1 or FM-2
+// findings are present and operator review is required.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// coveredEntry records a live tool that is covered by an exact manifest entry.
+type coveredEntry struct {
+	Tool     string
+	Resource string
+}
+
+// liveReport holds the classified findings from a live drift check.
+type liveReport struct {
+	exactCovered []coveredEntry // tools covered by exact-match entries
+	fm1Warnings  []DriftWarning // FM-1: glob-matched tools
+	fm3Warnings  []DriftWarning // FM-3: condition argument not in live schema
+	fm2Stale     []DriftWarning // FM-2: manifest entries with no live tool
+	uncovered    []string       // live tool names not covered by any manifest entry
+}
+
+// buildLiveReport classifies the live tool set against the manifest using
+// CheckManifestDrift and returns a liveReport ready for rendering.
+func buildLiveReport(manifest *LocalManifest, tools []UpstreamTool) liveReport {
+	driftWarnings := CheckManifestDrift(manifest, tools)
+
+	fm1 := make(map[string]DriftWarning)
+	fm2 := make(map[string]DriftWarning)
+	var fm3 []DriftWarning
+	uncoveredSet := make(map[string]bool)
+
+	for _, w := range driftWarnings {
+		switch w.Kind {
+		case DriftFM1:
+			fm1[w.Tool] = w
+		case DriftFM2:
+			fm2[w.Resource] = w
+		case DriftFM3:
+			fm3 = append(fm3, w)
+		case DriftUncovered:
+			uncoveredSet[w.Tool] = true
+		}
+	}
+
+	// Exact-covered: live tools that are NOT glob-matched (FM-1) and NOT uncovered.
+	var exactCovered []coveredEntry
+	for _, tool := range tools {
+		if uncoveredSet[tool.Name] {
+			continue
+		}
+		if _, isFM1 := fm1[tool.Name]; isFM1 {
+			continue
+		}
+		if c := bestManifestConstraint(manifest, tool.Name); c != nil {
+			exactCovered = append(exactCovered, coveredEntry{Tool: tool.Name, Resource: c.Resource})
+		}
+	}
+	sort.Slice(exactCovered, func(i, j int) bool {
+		return exactCovered[i].Tool < exactCovered[j].Tool
+	})
+
+	fm1Slice := make([]DriftWarning, 0, len(fm1))
+	for _, w := range fm1 {
+		fm1Slice = append(fm1Slice, w)
+	}
+	sort.Slice(fm1Slice, func(i, j int) bool {
+		return fm1Slice[i].Tool < fm1Slice[j].Tool
+	})
+
+	fm2Slice := make([]DriftWarning, 0, len(fm2))
+	for _, w := range fm2 {
+		fm2Slice = append(fm2Slice, w)
+	}
+	sort.Slice(fm2Slice, func(i, j int) bool {
+		return fm2Slice[i].Resource < fm2Slice[j].Resource
+	})
+
+	uncoveredSlice := make([]string, 0, len(uncoveredSet))
+	for name := range uncoveredSet {
+		uncoveredSlice = append(uncoveredSlice, name)
+	}
+	sort.Strings(uncoveredSlice)
+
+	return liveReport{
+		exactCovered: exactCovered,
+		fm1Warnings:  fm1Slice,
+		fm3Warnings:  fm3,
+		fm2Stale:     fm2Slice,
+		uncovered:    uncoveredSlice,
+	}
+}
+
+// runValidateLive writes a human-readable drift report to out and returns the
+// appropriate exit code.
+//
+// Returns 0 when the manifest is clean (no FM-1, no FM-2).
+// Returns 1 when warnings or stale entries are present.
+func runValidateLive(manifest *LocalManifest, tools []UpstreamTool, out io.Writer) int {
+	rep := buildLiveReport(manifest, tools)
+
+	// wf and wln are write helpers: errors on terminal output are not actionable
+	// by the caller, so they are intentionally discarded.
+	wf := func(format string, args ...interface{}) { _, _ = fmt.Fprintf(out, format, args...) }
+	wln := func(args ...interface{}) { _, _ = fmt.Fprintln(out, args...) }
+
+	// gap emits a blank line between sections, but not before the first one.
+	printed := false
+	gap := func() {
+		if printed {
+			wln()
+		}
+		printed = true
+	}
+
+	if len(rep.exactCovered) > 0 {
+		gap()
+		wln("COVERED")
+		for _, e := range rep.exactCovered {
+			wf("  ✓ %-22s resource: %s\n", e.Tool, e.Resource)
+		}
+	}
+
+	if len(rep.fm1Warnings) > 0 || len(rep.fm3Warnings) > 0 {
+		gap()
+		wln("WARNINGS")
+		for _, w := range rep.fm1Warnings {
+			wf("  ⚠ %-22s resource: %-22s (glob match — confirm this is intended)\n", w.Tool, w.Resource)
+		}
+		for _, w := range rep.fm3Warnings {
+			wf("  ⚠ %-22s argument=%q not in live inputSchema  (resource: %s)\n", w.Tool, w.Argument, w.Resource)
+		}
+	}
+
+	if len(rep.uncovered) > 0 {
+		gap()
+		wln("NOT COVERED (denied by default)")
+		for _, name := range rep.uncovered {
+			wf("  - %s\n", name)
+		}
+	}
+
+	if len(rep.fm2Stale) > 0 {
+		gap()
+		wln("STALE MANIFEST ENTRIES")
+		for _, w := range rep.fm2Stale {
+			wf("  ✗ %s  — no matching upstream tool\n", w.Resource)
+		}
+	}
+
+	gap()
+
+	fm1Count := len(rep.fm1Warnings)
+	fm2Count := len(rep.fm2Stale)
+
+	if fm1Count == 0 && fm2Count == 0 {
+		wln("Result: ok — all manifest entries match live tools; no glob matches detected.")
+		return 0
+	}
+
+	var parts []string
+	if fm1Count == 1 {
+		parts = append(parts, "1 glob match")
+	} else if fm1Count > 1 {
+		parts = append(parts, fmt.Sprintf("%d glob matches", fm1Count))
+	}
+	if fm2Count == 1 {
+		parts = append(parts, "1 stale entry")
+	} else if fm2Count > 1 {
+		parts = append(parts, fmt.Sprintf("%d stale entries", fm2Count))
+	}
+	wf("Result: %s. Exit 1.\n", strings.Join(parts, ", "))
+	return 1
+}

--- a/cmd/mcp/validate_live.go
+++ b/cmd/mcp/validate_live.go
@@ -35,18 +35,20 @@ type liveReport struct {
 	exactCovered []coveredEntry // tools covered by exact-match entries
 	fm1Warnings  []DriftWarning // FM-1: glob-matched tools
 	fm3Warnings  []DriftWarning // FM-3: condition argument not in live schema
+	fm4Warnings  []DriftWarning // FM-4: server version does not satisfy manifest pin
 	fm2Stale     []DriftWarning // FM-2: manifest entries with no live tool
 	uncovered    []string       // live tool names not covered by any manifest entry
 }
 
 // buildLiveReport classifies the live tool set against the manifest using
 // CheckManifestDrift and returns a liveReport ready for rendering.
-func buildLiveReport(manifest *LocalManifest, tools []UpstreamTool) liveReport {
-	driftWarnings := CheckManifestDrift(manifest, tools)
+// serverVersion is the version string from the upstream initialize response.
+func buildLiveReport(manifest *LocalManifest, tools []UpstreamTool, serverVersion string) liveReport {
+	driftWarnings := CheckManifestDrift(manifest, tools, serverVersion)
 
 	fm1 := make(map[string]DriftWarning)
 	fm2 := make(map[string]DriftWarning)
-	var fm3 []DriftWarning
+	var fm3, fm4 []DriftWarning
 	uncoveredSet := make(map[string]bool)
 
 	for _, w := range driftWarnings {
@@ -57,6 +59,8 @@ func buildLiveReport(manifest *LocalManifest, tools []UpstreamTool) liveReport {
 			fm2[w.Resource] = w
 		case DriftFM3:
 			fm3 = append(fm3, w)
+		case DriftFM4:
+			fm4 = append(fm4, w)
 		case DriftUncovered:
 			uncoveredSet[w.Tool] = true
 		}
@@ -105,6 +109,7 @@ func buildLiveReport(manifest *LocalManifest, tools []UpstreamTool) liveReport {
 		exactCovered: exactCovered,
 		fm1Warnings:  fm1Slice,
 		fm3Warnings:  fm3,
+		fm4Warnings:  fm4,
 		fm2Stale:     fm2Slice,
 		uncovered:    uncoveredSlice,
 	}
@@ -113,10 +118,10 @@ func buildLiveReport(manifest *LocalManifest, tools []UpstreamTool) liveReport {
 // runValidateLive writes a human-readable drift report to out and returns the
 // appropriate exit code.
 //
-// Returns 0 when the manifest is clean (no FM-1, no FM-2).
+// Returns 0 when the manifest is clean (no FM-1, no FM-2, no FM-4).
 // Returns 1 when warnings or stale entries are present.
-func runValidateLive(manifest *LocalManifest, tools []UpstreamTool, out io.Writer) int {
-	rep := buildLiveReport(manifest, tools)
+func runValidateLive(manifest *LocalManifest, tools []UpstreamTool, serverVersion string, out io.Writer) int {
+	rep := buildLiveReport(manifest, tools, serverVersion)
 
 	// wf and wln are write helpers: errors on terminal output are not actionable
 	// by the caller, so they are intentionally discarded.
@@ -140,9 +145,16 @@ func runValidateLive(manifest *LocalManifest, tools []UpstreamTool, out io.Write
 		}
 	}
 
-	if len(rep.fm1Warnings) > 0 || len(rep.fm3Warnings) > 0 {
+	if len(rep.fm4Warnings) > 0 || len(rep.fm1Warnings) > 0 || len(rep.fm3Warnings) > 0 {
 		gap()
 		wln("WARNINGS")
+		for _, w := range rep.fm4Warnings {
+			actual := w.VersionActual
+			if actual == "" {
+				actual = "(unknown)"
+			}
+			wf("  ⚠ SERVER VERSION MISMATCH  pinned: %-18s actual: %s\n", w.Resource, actual)
+		}
 		for _, w := range rep.fm1Warnings {
 			wf("  ⚠ %-22s resource: %-22s (glob match — confirm this is intended)\n", w.Tool, w.Resource)
 		}
@@ -171,13 +183,17 @@ func runValidateLive(manifest *LocalManifest, tools []UpstreamTool, out io.Write
 
 	fm1Count := len(rep.fm1Warnings)
 	fm2Count := len(rep.fm2Stale)
+	fm4Count := len(rep.fm4Warnings)
 
-	if fm1Count == 0 && fm2Count == 0 {
+	if fm1Count == 0 && fm2Count == 0 && fm4Count == 0 {
 		wln("Result: ok — all manifest entries match live tools; no glob matches detected.")
 		return 0
 	}
 
 	var parts []string
+	if fm4Count > 0 {
+		parts = append(parts, "server version mismatch")
+	}
 	if fm1Count == 1 {
 		parts = append(parts, "1 glob match")
 	} else if fm1Count > 1 {

--- a/cmd/mcp/validate_live_test.go
+++ b/cmd/mcp/validate_live_test.go
@@ -19,7 +19,7 @@ func TestBuildLiveReport_ExactCovered(t *testing.T) {
 	)
 	tools := []UpstreamTool{{Name: "read_file"}, {Name: "query_db"}}
 
-	rep := buildLiveReport(manifest, tools)
+	rep := buildLiveReport(manifest, tools, "")
 
 	if len(rep.exactCovered) != 2 {
 		t.Fatalf("exactCovered: want 2, got %d", len(rep.exactCovered))
@@ -44,7 +44,7 @@ func TestBuildLiveReport_GlobMatchedGoesToFM1(t *testing.T) {
 	)
 	tools := []UpstreamTool{{Name: "get_customer"}, {Name: "get_invoice"}}
 
-	rep := buildLiveReport(manifest, tools)
+	rep := buildLiveReport(manifest, tools, "")
 
 	if len(rep.exactCovered) != 0 {
 		t.Errorf("exactCovered: want 0 (glob matches should not appear here), got %d", len(rep.exactCovered))
@@ -66,7 +66,7 @@ func TestBuildLiveReport_FM2StaleEntries(t *testing.T) {
 	)
 	tools := []UpstreamTool{{Name: "new_search"}}
 
-	rep := buildLiveReport(manifest, tools)
+	rep := buildLiveReport(manifest, tools, "")
 
 	if len(rep.fm2Stale) != 2 {
 		t.Errorf("fm2Stale: want 2, got %d", len(rep.fm2Stale))
@@ -88,7 +88,7 @@ func TestBuildLiveReport_Uncovered(t *testing.T) {
 		{Name: "delete_file"},
 	}
 
-	rep := buildLiveReport(manifest, tools)
+	rep := buildLiveReport(manifest, tools, "")
 
 	if len(rep.uncovered) != 2 {
 		t.Fatalf("uncovered: want 2, got %d: %v", len(rep.uncovered), rep.uncovered)
@@ -119,7 +119,7 @@ func TestBuildLiveReport_FM3Advisory(t *testing.T) {
 		},
 	}}
 
-	rep := buildLiveReport(manifest, tools)
+	rep := buildLiveReport(manifest, tools, "")
 
 	// read_file is exact-matched → should appear in exactCovered (not in fm1).
 	if len(rep.exactCovered) != 1 || rep.exactCovered[0].Tool != "read_file" {
@@ -143,7 +143,7 @@ func TestRunValidateLive_CleanManifest_Exit0(t *testing.T) {
 	tools := []UpstreamTool{{Name: "read_file"}, {Name: "query_db"}}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 0 {
 		t.Errorf("clean manifest: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
@@ -173,7 +173,7 @@ func TestRunValidateLive_FM1GlobMatch_Exit1(t *testing.T) {
 	tools := []UpstreamTool{{Name: "delete_all_records"}}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 1 {
 		t.Errorf("glob match: expected exit 1, got %d", code)
@@ -204,7 +204,7 @@ func TestRunValidateLive_FM2StaleEntry_Exit1(t *testing.T) {
 	tools := []UpstreamTool{{Name: "new_search"}}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 1 {
 		t.Errorf("stale entry: expected exit 1, got %d", code)
@@ -232,7 +232,7 @@ func TestRunValidateLive_UncoveredTools_Exit0(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 0 {
 		t.Errorf("uncovered only: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
@@ -268,7 +268,7 @@ func TestRunValidateLive_FM3Advisory_Exit0(t *testing.T) {
 	}}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 0 {
 		t.Errorf("FM-3 advisory: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
@@ -300,7 +300,7 @@ func TestRunValidateLive_Mixed(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 1 {
 		t.Errorf("mixed: expected exit 1, got %d", code)
@@ -340,7 +340,7 @@ func TestRunValidateLive_MultipleGlobMatches_PluralResult(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 1 {
 		t.Errorf("3 glob matches: expected exit 1, got %d", code)
@@ -358,7 +358,7 @@ func TestRunValidateLive_MultipleStaleEntries_PluralResult(t *testing.T) {
 	tools := []UpstreamTool{{Name: "new_tool"}}
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, tools, &buf)
+	code := runValidateLive(manifest, tools, "", &buf)
 
 	if code != 1 {
 		t.Errorf("2 stale entries: expected exit 1, got %d", code)
@@ -375,7 +375,7 @@ func TestRunValidateLive_EmptyToolList_Exit1(t *testing.T) {
 	)
 
 	var buf strings.Builder
-	code := runValidateLive(manifest, nil, &buf)
+	code := runValidateLive(manifest, nil, "", &buf)
 
 	if code != 1 {
 		t.Errorf("empty tools: expected exit 1 (stale manifest), got %d", code)
@@ -393,7 +393,7 @@ func TestRunValidateLive_SectionsOmittedWhenEmpty(t *testing.T) {
 	tools := []UpstreamTool{{Name: "read_file"}}
 
 	var buf strings.Builder
-	runValidateLive(manifest, tools, &buf)
+	runValidateLive(manifest, tools, "", &buf)
 	out := buf.String()
 
 	for _, absent := range []string{"WARNINGS", "NOT COVERED", "STALE"} {
@@ -410,7 +410,7 @@ func TestRunValidateLive_ExactMatchLabelInCovered(t *testing.T) {
 	tools := []UpstreamTool{{Name: "read_file"}}
 
 	var buf strings.Builder
-	runValidateLive(manifest, tools, &buf)
+	runValidateLive(manifest, tools, "", &buf)
 
 	// The COVERED line should show the resource name.
 	out := buf.String()
@@ -430,11 +430,133 @@ func TestRunValidateLive_BlankLineBetweenSections(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	runValidateLive(manifest, tools, &buf)
+	runValidateLive(manifest, tools, "", &buf)
 	out := buf.String()
 
 	// There must be at least one blank line in the output (section separator).
 	if !strings.Contains(out, "\n\n") {
 		t.Error("output should contain at least one blank line between sections")
+	}
+}
+
+// ─── FM-4: server version pinning ────────────────────────────────────────────
+
+func TestBuildLiveReport_FM4_VersionMismatch(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.3"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	rep := buildLiveReport(manifest, tools, "1.3.0")
+
+	if len(rep.fm4Warnings) != 1 {
+		t.Fatalf("fm4Warnings: want 1, got %d", len(rep.fm4Warnings))
+	}
+	if rep.fm4Warnings[0].Resource != "1.2.3" {
+		t.Errorf("fm4Warnings[0].Resource: want 1.2.3, got %q", rep.fm4Warnings[0].Resource)
+	}
+	if rep.fm4Warnings[0].VersionActual != "1.3.0" {
+		t.Errorf("fm4Warnings[0].VersionActual: want 1.3.0, got %q", rep.fm4Warnings[0].VersionActual)
+	}
+}
+
+func TestBuildLiveReport_FM4_VersionMatch(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.*"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	rep := buildLiveReport(manifest, tools, "1.2.5")
+
+	if len(rep.fm4Warnings) != 0 {
+		t.Errorf("fm4Warnings: want 0, got %d (wildcard match should not fire)", len(rep.fm4Warnings))
+	}
+}
+
+func TestRunValidateLive_FM4VersionMismatch_Exit1(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.3"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, "2.0.0", &buf)
+
+	if code != 1 {
+		t.Errorf("version mismatch: expected exit 1, got %d", code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARNINGS") {
+		t.Error("FM-4 should appear in WARNINGS section")
+	}
+	if !strings.Contains(out, "SERVER VERSION MISMATCH") {
+		t.Error("FM-4 should show SERVER VERSION MISMATCH label")
+	}
+	if !strings.Contains(out, "1.2.3") {
+		t.Error("output should show the pinned constraint")
+	}
+	if !strings.Contains(out, "2.0.0") {
+		t.Error("output should show the actual version")
+	}
+	if !strings.Contains(out, "server version mismatch") {
+		t.Error("result line should mention server version mismatch")
+	}
+}
+
+func TestRunValidateLive_FM4VersionMatch_NoWarning(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.2.*"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, "1.2.5", &buf)
+
+	if code != 0 {
+		t.Errorf("wildcard version match: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
+	}
+	if strings.Contains(buf.String(), "SERVER VERSION MISMATCH") {
+		t.Error("output must not contain SERVER VERSION MISMATCH for matching version")
+	}
+}
+
+func TestRunValidateLive_FM4UnknownVersion_Exit1(t *testing.T) {
+	// Server doesn't report a version but manifest has a pin.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	manifest.ServerVersion = "1.0.0"
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, "", &buf)
+
+	if code != 1 {
+		t.Errorf("unknown version with pin: expected exit 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "(unknown)") {
+		t.Error("output should show (unknown) when server version is absent")
+	}
+}
+
+func TestRunValidateLive_FM4NoPinConfigured_NoWarning(t *testing.T) {
+	// No serverVersion in manifest — FM-4 must never fire regardless of actual.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, "99.0.0", &buf)
+
+	if code != 0 {
+		t.Errorf("no pin configured: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
+	}
+	if strings.Contains(buf.String(), "SERVER VERSION") {
+		t.Error("no server version warning expected when no pin is configured")
 	}
 }

--- a/cmd/mcp/validate_live_test.go
+++ b/cmd/mcp/validate_live_test.go
@@ -1,0 +1,440 @@
+// Copyright 2026 Eunolabs, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eunolabs/eunox/pkg/capability"
+)
+
+// ─── buildLiveReport ─────────────────────────────────────────────────────────
+
+func TestBuildLiveReport_ExactCovered(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+		capability.Constraint{Resource: "query_db", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "read_file"}, {Name: "query_db"}}
+
+	rep := buildLiveReport(manifest, tools)
+
+	if len(rep.exactCovered) != 2 {
+		t.Fatalf("exactCovered: want 2, got %d", len(rep.exactCovered))
+	}
+	if rep.exactCovered[0].Tool != "query_db" {
+		t.Errorf("exactCovered[0]: want query_db (sorted), got %q", rep.exactCovered[0].Tool)
+	}
+	if len(rep.fm1Warnings) != 0 {
+		t.Errorf("fm1Warnings: want 0, got %d", len(rep.fm1Warnings))
+	}
+	if len(rep.fm2Stale) != 0 {
+		t.Errorf("fm2Stale: want 0, got %d", len(rep.fm2Stale))
+	}
+	if len(rep.uncovered) != 0 {
+		t.Errorf("uncovered: want 0, got %d", len(rep.uncovered))
+	}
+}
+
+func TestBuildLiveReport_GlobMatchedGoesToFM1(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "get_*", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "get_customer"}, {Name: "get_invoice"}}
+
+	rep := buildLiveReport(manifest, tools)
+
+	if len(rep.exactCovered) != 0 {
+		t.Errorf("exactCovered: want 0 (glob matches should not appear here), got %d", len(rep.exactCovered))
+	}
+	if len(rep.fm1Warnings) != 2 {
+		t.Errorf("fm1Warnings: want 2, got %d", len(rep.fm1Warnings))
+	}
+	// FM-1 slice must be sorted by tool name.
+	if rep.fm1Warnings[0].Tool != "get_customer" || rep.fm1Warnings[1].Tool != "get_invoice" {
+		t.Errorf("fm1Warnings order: want [get_customer, get_invoice], got [%s, %s]",
+			rep.fm1Warnings[0].Tool, rep.fm1Warnings[1].Tool)
+	}
+}
+
+func TestBuildLiveReport_FM2StaleEntries(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "legacy_search", Actions: []string{"call"}},
+		capability.Constraint{Resource: "old_export", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "new_search"}}
+
+	rep := buildLiveReport(manifest, tools)
+
+	if len(rep.fm2Stale) != 2 {
+		t.Errorf("fm2Stale: want 2, got %d", len(rep.fm2Stale))
+	}
+	// FM-2 slice must be sorted by resource name.
+	if rep.fm2Stale[0].Resource != "legacy_search" || rep.fm2Stale[1].Resource != "old_export" {
+		t.Errorf("fm2Stale order: want [legacy_search, old_export], got [%s, %s]",
+			rep.fm2Stale[0].Resource, rep.fm2Stale[1].Resource)
+	}
+}
+
+func TestBuildLiveReport_Uncovered(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{
+		{Name: "read_file"},
+		{Name: "write_file"},
+		{Name: "delete_file"},
+	}
+
+	rep := buildLiveReport(manifest, tools)
+
+	if len(rep.uncovered) != 2 {
+		t.Fatalf("uncovered: want 2, got %d: %v", len(rep.uncovered), rep.uncovered)
+	}
+	// Uncovered tools must be sorted.
+	if rep.uncovered[0] != "delete_file" || rep.uncovered[1] != "write_file" {
+		t.Errorf("uncovered order: want [delete_file, write_file], got %v", rep.uncovered)
+	}
+}
+
+func TestBuildLiveReport_FM3Advisory(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{
+			Resource: "read_file",
+			Actions:  []string{"call"},
+			Conditions: []capability.Condition{
+				capability.AllowedValuesCondition{Argument: "path", Values: []interface{}{"/reports/*"}},
+			},
+		},
+	)
+	tools := []UpstreamTool{{
+		Name: "read_file",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"file_path": map[string]interface{}{"type": "string"},
+			},
+		},
+	}}
+
+	rep := buildLiveReport(manifest, tools)
+
+	// read_file is exact-matched → should appear in exactCovered (not in fm1).
+	if len(rep.exactCovered) != 1 || rep.exactCovered[0].Tool != "read_file" {
+		t.Errorf("exactCovered: want [{read_file,...}], got %v", rep.exactCovered)
+	}
+	if len(rep.fm3Warnings) != 1 {
+		t.Errorf("fm3Warnings: want 1, got %d", len(rep.fm3Warnings))
+	}
+	if rep.fm3Warnings[0].Argument != "path" {
+		t.Errorf("fm3Warnings[0].Argument: want path, got %q", rep.fm3Warnings[0].Argument)
+	}
+}
+
+// ─── runValidateLive ─────────────────────────────────────────────────────────
+
+func TestRunValidateLive_CleanManifest_Exit0(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+		capability.Constraint{Resource: "query_db", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "read_file"}, {Name: "query_db"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 0 {
+		t.Errorf("clean manifest: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "COVERED") {
+		t.Error("clean manifest: output should have COVERED section")
+	}
+	if !strings.Contains(out, "read_file") {
+		t.Error("clean manifest: output should mention read_file")
+	}
+	if !strings.Contains(out, "query_db") {
+		t.Error("clean manifest: output should mention query_db")
+	}
+	if strings.Contains(out, "WARNINGS") {
+		t.Error("clean manifest: output must not have WARNINGS section")
+	}
+	if !strings.Contains(out, "ok") {
+		t.Error("clean manifest: result should say ok")
+	}
+}
+
+func TestRunValidateLive_FM1GlobMatch_Exit1(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "delete_*", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "delete_all_records"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 1 {
+		t.Errorf("glob match: expected exit 1, got %d", code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARNINGS") {
+		t.Error("should have WARNINGS section for FM-1")
+	}
+	if !strings.Contains(out, "delete_all_records") {
+		t.Error("should mention delete_all_records in WARNINGS")
+	}
+	if !strings.Contains(out, "glob match") {
+		t.Error("should say 'glob match' in WARNINGS")
+	}
+	// Glob-matched tool must NOT appear in COVERED (it's not exact-matched).
+	if strings.Contains(out, "COVERED") {
+		t.Error("output must not have COVERED section when all tools are glob-matched")
+	}
+	if !strings.Contains(out, "Exit 1") {
+		t.Error("result should say Exit 1")
+	}
+}
+
+func TestRunValidateLive_FM2StaleEntry_Exit1(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "legacy_search", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "new_search"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 1 {
+		t.Errorf("stale entry: expected exit 1, got %d", code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "STALE MANIFEST ENTRIES") {
+		t.Error("should have STALE MANIFEST ENTRIES section")
+	}
+	if !strings.Contains(out, "legacy_search") {
+		t.Error("should mention legacy_search as stale")
+	}
+	if !strings.Contains(out, "stale entry") {
+		t.Error("result should say 'stale entry'")
+	}
+}
+
+func TestRunValidateLive_UncoveredTools_Exit0(t *testing.T) {
+	// Uncovered tools are informational and do not cause exit 1.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{
+		{Name: "read_file"},
+		{Name: "uncovered_tool"},
+	}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 0 {
+		t.Errorf("uncovered only: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "NOT COVERED") {
+		t.Error("should have NOT COVERED section")
+	}
+	if !strings.Contains(out, "uncovered_tool") {
+		t.Error("should mention uncovered_tool")
+	}
+}
+
+func TestRunValidateLive_FM3Advisory_Exit0(t *testing.T) {
+	// FM-3 is advisory — it produces a WARNINGS line but does not cause exit 1.
+	manifest := manifestWith(
+		capability.Constraint{
+			Resource: "read_file",
+			Actions:  []string{"call"},
+			Conditions: []capability.Condition{
+				capability.AllowedValuesCondition{Argument: "path", Values: []interface{}{"/reports/*"}},
+			},
+		},
+	)
+	tools := []UpstreamTool{{
+		Name: "read_file",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"file_path": map[string]interface{}{"type": "string"},
+			},
+		},
+	}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 0 {
+		t.Errorf("FM-3 advisory: expected exit 0, got %d\nOutput:\n%s", code, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARNINGS") {
+		t.Error("FM-3 should appear in WARNINGS section")
+	}
+	if !strings.Contains(out, `"path"`) {
+		t.Error("output should mention the missing argument name")
+	}
+	// read_file is exact-matched → must appear in COVERED too.
+	if !strings.Contains(out, "COVERED") {
+		t.Error("read_file should still appear in COVERED (exact match)")
+	}
+}
+
+func TestRunValidateLive_Mixed(t *testing.T) {
+	// Scenario: one exact match, one glob match, one stale entry, one uncovered tool.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+		capability.Constraint{Resource: "get_*", Actions: []string{"call"}},
+		capability.Constraint{Resource: "legacy_tool", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{
+		{Name: "read_file"},
+		{Name: "get_customer"},
+		{Name: "uncovered_tool"},
+	}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 1 {
+		t.Errorf("mixed: expected exit 1, got %d", code)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "COVERED") || !strings.Contains(out, "read_file") {
+		t.Error("read_file should appear in COVERED (exact match)")
+	}
+	if !strings.Contains(out, "WARNINGS") || !strings.Contains(out, "get_customer") {
+		t.Error("get_customer should appear in WARNINGS (glob match)")
+	}
+	if !strings.Contains(out, "NOT COVERED") || !strings.Contains(out, "uncovered_tool") {
+		t.Error("uncovered_tool should appear in NOT COVERED")
+	}
+	if !strings.Contains(out, "STALE MANIFEST ENTRIES") || !strings.Contains(out, "legacy_tool") {
+		t.Error("legacy_tool should appear in STALE MANIFEST ENTRIES")
+	}
+
+	// Result should summarise both findings.
+	if !strings.Contains(out, "glob match") {
+		t.Error("result should mention glob match(es)")
+	}
+	if !strings.Contains(out, "stale entry") {
+		t.Error("result should mention stale entry(ies)")
+	}
+}
+
+func TestRunValidateLive_MultipleGlobMatches_PluralResult(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "get_*", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{
+		{Name: "get_customer"},
+		{Name: "get_invoice"},
+		{Name: "get_report"},
+	}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 1 {
+		t.Errorf("3 glob matches: expected exit 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "3 glob matches") {
+		t.Errorf("result should say '3 glob matches', got: %s", buf.String())
+	}
+}
+
+func TestRunValidateLive_MultipleStaleEntries_PluralResult(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "old_tool_a", Actions: []string{"call"}},
+		capability.Constraint{Resource: "old_tool_b", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "new_tool"}}
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, tools, &buf)
+
+	if code != 1 {
+		t.Errorf("2 stale entries: expected exit 1, got %d", code)
+	}
+	if !strings.Contains(buf.String(), "2 stale entries") {
+		t.Errorf("result should say '2 stale entries', got: %s", buf.String())
+	}
+}
+
+func TestRunValidateLive_EmptyToolList_Exit1(t *testing.T) {
+	// Empty tool list means every manifest entry is stale.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+
+	var buf strings.Builder
+	code := runValidateLive(manifest, nil, &buf)
+
+	if code != 1 {
+		t.Errorf("empty tools: expected exit 1 (stale manifest), got %d", code)
+	}
+	if !strings.Contains(buf.String(), "STALE") {
+		t.Error("should have STALE section for empty tool list")
+	}
+}
+
+func TestRunValidateLive_SectionsOmittedWhenEmpty(t *testing.T) {
+	// Clean manifest — only COVERED should be present.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	var buf strings.Builder
+	runValidateLive(manifest, tools, &buf)
+	out := buf.String()
+
+	for _, absent := range []string{"WARNINGS", "NOT COVERED", "STALE"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("section %q should be absent for clean manifest", absent)
+		}
+	}
+}
+
+func TestRunValidateLive_ExactMatchLabelInCovered(t *testing.T) {
+	manifest := manifestWith(
+		capability.Constraint{Resource: "read_file", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{{Name: "read_file"}}
+
+	var buf strings.Builder
+	runValidateLive(manifest, tools, &buf)
+
+	// The COVERED line should show the resource name.
+	out := buf.String()
+	if !strings.Contains(out, "read_file") {
+		t.Error("COVERED should show the resource name")
+	}
+}
+
+func TestRunValidateLive_BlankLineBetweenSections(t *testing.T) {
+	// When multiple sections are present there should be a blank line between them.
+	manifest := manifestWith(
+		capability.Constraint{Resource: "get_*", Actions: []string{"call"}},
+	)
+	tools := []UpstreamTool{
+		{Name: "get_customer"},
+		{Name: "uncovered_tool"},
+	}
+
+	var buf strings.Builder
+	runValidateLive(manifest, tools, &buf)
+	out := buf.String()
+
+	// There must be at least one blank line in the output (section separator).
+	if !strings.Contains(out, "\n\n") {
+		t.Error("output should contain at least one blank line between sections")
+	}
+}

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -36,6 +36,7 @@ up-jwt:
 	@mkdir -p "$(DEMO_DIR)audit"
 	@chmod 777 "$(DEMO_DIR)audit"
 	docker compose \
+	  --profile jwt \
 	  -f "$(DEMO_DIR)docker-compose.yml" \
 	  -f "$(DEMO_DIR)docker-compose.jwt.yml" \
 	  up --build -d
@@ -122,11 +123,12 @@ logs:
 # ─────────────────────────────────────────────────────────────────────────────
 
 ## ci-test: Run manifest-only integration tests in CI (starts stack, tests, tears down).
+## Keycloak is excluded entirely via the "jwt" profile — its image is never pulled.
 ci-test:
 	@mkdir -p "$(DEMO_DIR)audit" && chmod 777 "$(DEMO_DIR)audit"
-	@echo "==> Starting manifest-only stack for CI tests (Keycloak skipped) ..."
+	@echo "==> Starting manifest-only stack for CI tests (Keycloak excluded by profile) ..."
 	@docker compose -f "$(DEMO_DIR)docker-compose.yml" \
-	  up --build --force-recreate -d --wait --scale keycloak=0 \
+	  up --build --force-recreate -d --wait \
 	  && bash "$(DEMO_DIR)scripts/ci-test.sh"; STATUS=$$?; \
 	  docker compose -f "$(DEMO_DIR)docker-compose.yml" down --remove-orphans; \
 	  exit $$STATUS
@@ -136,11 +138,13 @@ ci-test-jwt:
 	@mkdir -p "$(DEMO_DIR)audit" && chmod 777 "$(DEMO_DIR)audit"
 	@echo "==> Starting JWT-mode stack for CI tests (Keycloak + eunox-mcp) ..."
 	@docker compose \
+	  --profile jwt \
 	  -f "$(DEMO_DIR)docker-compose.yml" \
 	  -f "$(DEMO_DIR)docker-compose.jwt.yml" \
 	  up --build --force-recreate -d --wait \
 	  && bash "$(DEMO_DIR)scripts/ci-test-jwt.sh"; STATUS=$$?; \
 	  docker compose \
+	    --profile jwt \
 	    -f "$(DEMO_DIR)docker-compose.yml" \
 	    -f "$(DEMO_DIR)docker-compose.jwt.yml" \
 	    down --remove-orphans; \

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -43,9 +43,14 @@ services:
   # ── keycloak ───────────────────────────────────────────────────────
   # Keycloak pre-seeded with the eunox-demo realm.  The demo-agent
   # client uses client-credentials flow and carries mcp.capabilities
-  # claims in every access token (JWT mode only; run `make jwt`).
+  # claims in every access token (JWT mode only; run `make up-jwt`).
+  #
+  # profiles: ["jwt"] keeps this service out of the default compose
+  # set so that `make up` (manifest-only) never pulls the image.
+  # Activate with: docker compose --profile jwt up
   keycloak:
     image: quay.io/keycloak/keycloak:26.0
+    profiles: ["jwt"]
     command:
       - start-dev
       - --import-realm

--- a/docs/mcp-contract-drift.md
+++ b/docs/mcp-contract-drift.md
@@ -82,15 +82,48 @@ condition to silently pass by never matching. The invariant to protect
 is: a condition that was intended to restrict must not silently become a
 no-op.
 
-### FM-4 — Undetectable behavior drift (out of scope for proxy)
+### FM-4 — Server version mismatch (detectable via version pin)
 
 A tool retains its name and argument schema but its server-side
 implementation changes. For example, `read_file` begins exfiltrating
 file metadata to a telemetry endpoint after a server update. The proxy
-cannot detect this because it inspects the _wire contract_, not the
-_implementation_. This is a supply-chain trust problem addressed by
-deployment controls (pinned container image digests, sandboxing) rather
-than manifest policy.
+cannot detect implementation changes directly, but it **can** detect
+that the server version changed — provided the manifest declares a
+`serverVersion` pin.
+
+**Detected when `serverVersion` is set in the manifest.** The proxy
+compares the version string from the upstream `initialize` response
+against the pinned constraint and emits an FM-4 warning on mismatch.
+
+```yaml
+# manifest.yaml
+name: "my-policy"
+version: "1.0.0"
+serverVersion: "1.2.*"   # allow any patch of 1.2; reject 1.3+
+capabilities:
+  - resource: read_file
+    actions: [call]
+```
+
+Supported constraint forms:
+
+| Constraint | Matches |
+|---|---|
+| `1.2.3` | exactly `1.2.3` |
+| `1.2.*` | `1.2.x` for any patch `x` |
+| `1.*`   | `1.x.y` for any minor and patch |
+| `*`     | any version (effectively no pin) |
+
+**Without `serverVersion` in the manifest:** FM-4 is never emitted —
+existing manifests are unaffected.
+
+**In `--strict-drift` mode:** FM-4 aborts session establishment (like
+FM-1 and FM-2), preventing an agent from connecting to an unexpected
+server version.
+
+**Purely behavioral changes** (same version, changed implementation)
+cannot be detected at the proxy layer and remain a supply-chain concern
+addressed by deployment controls.
 
 ---
 
@@ -303,9 +336,9 @@ perspective. Mitigations are external:
 |---|---|---|---|
 | Fix 1 — Startup drift warnings | Low | FM-1, FM-2 | ✅ **Shipped** (`cmd/mcp/drift.go`) |
 | Fix 3 — Argument schema drift | Low | FM-3 | ✅ **Shipped** (Fix 1 extended; `argumentSchema` pinning documented) |
-| Fix 2 — `validate --live` | Medium | FM-1, FM-2, FM-3 | ✅ **Shipped** (`cmd/mcp/validate_live.go`; `--live` flag on `validate`) |
+| Fix 2 — `validate --live` | Medium | FM-1, FM-2, FM-3, FM-4 | ✅ **Shipped** (`cmd/mcp/validate_live.go`; `--live` flag on `validate`) |
 | Fix 4 — `init` scaffold | Medium | Authoring UX | ✅ **Shipped** (`cmd/mcp/init_manifest.go`; `init` subcommand) |
-| FM-4 — Behavior drift | Not solvable at proxy | — | Supply-chain / deployment controls |
+| FM-4 — Version pin | Low | FM-4 | ✅ **Shipped** (`serverVersion` manifest field; `cmd/mcp/drift.go`) |
 
 ---
 

--- a/docs/mcp-contract-drift.md
+++ b/docs/mcp-contract-drift.md
@@ -127,7 +127,7 @@ establishment is not blocked).
 errors, aborting session establishment with HTTP 500.  FM-3 findings
 and uncovered-tool infos remain advisory even in strict mode.
 
-### Fix 2 — `eunox-mcp validate --live` subcommand (medium effort)
+### Fix 2 — `eunox-mcp validate --live` subcommand ✅ **Implemented**
 
 A new `validate` flag that connects to a live upstream, fetches
 `tools/list`, and runs a complete diff against the manifest:
@@ -226,7 +226,7 @@ When the server renames `path` to `file_path`, the proxy rejects every
 call at schema validation rather than silently applying the condition
 to a missing argument.
 
-### Fix 4 — `eunox-mcp init` scaffold (medium effort)
+### Fix 4 — `eunox-mcp init` scaffold ✅ **Implemented**
 
 A new `init` subcommand connects to a live upstream and generates a
 starter manifest with one deny-all entry per tool:
@@ -303,20 +303,34 @@ perspective. Mitigations are external:
 |---|---|---|---|
 | Fix 1 — Startup drift warnings | Low | FM-1, FM-2 | ✅ **Shipped** (`cmd/mcp/drift.go`) |
 | Fix 3 — Argument schema drift | Low | FM-3 | ✅ **Shipped** (Fix 1 extended; `argumentSchema` pinning documented) |
-| Fix 2 — `validate --live` | Medium | FM-1, FM-2, FM-3 | Post-MVP milestone |
-| Fix 4 — `init` scaffold | Medium | Authoring UX | Post-MVP milestone |
+| Fix 2 — `validate --live` | Medium | FM-1, FM-2, FM-3 | ✅ **Shipped** (`cmd/mcp/validate_live.go`; `--live` flag on `validate`) |
+| Fix 4 — `init` scaffold | Medium | Authoring UX | ✅ **Shipped** (`cmd/mcp/init_manifest.go`; `init` subcommand) |
 | FM-4 — Behavior drift | Not solvable at proxy | — | Supply-chain / deployment controls |
 
 ---
 
 ## Impact on the MVP release checklist
 
-The release checklist should include a **Stage 4** documentation item:
+The release checklist should include a **Stage 4** CI step:
 
-> Confirm that the upstream MCP server version deployed in the demo
-> matches the version used when the manifest was authored. If the
-> server has been updated since the manifest was last reviewed, run
-> `eunox-mcp validate` and inspect the tool list manually.
+```yaml
+# .github/workflows/manifest-drift.yml
+- name: Check manifest drift
+  run: |
+    eunox-mcp validate manifest.yaml \
+      --live \
+      --upstream-url ${{ vars.MCP_STAGING_URL }}
+```
 
-Until Fix 1 (startup warnings) ships, operators must verify manifest
-currency manually on every server update.
+Exit code 1 (glob matches or stale entries detected) fails the pipeline;
+policy authors review the diff and update the manifest before the server
+release ships to production.
+
+To bootstrap a manifest for a new server, run:
+
+```
+eunox-mcp init --upstream-url https://mcp.example.com --output manifest.yaml
+```
+
+Every tool starts commented out.  Uncomment and add conditions only for
+tools the agent genuinely needs, then commit the result.

--- a/internal/agentruntime/manifest.go
+++ b/internal/agentruntime/manifest.go
@@ -21,6 +21,12 @@ type AgentCapabilityManifest struct {
 	Version string `json:"version"`
 	// Description is an optional human-readable description of the agent.
 	Description string `json:"description,omitempty"`
+	// ServerVersion pins the upstream MCP server version the manifest was authored
+	// against.  Supports exact versions ("1.2.3") and trailing wildcards ("1.2.*",
+	// "1.*").  When set, the proxy emits an FM-4 drift warning (and, in
+	// --strict-drift mode, aborts) if the live server version does not match.
+	// Leave empty to disable version pinning.
+	ServerVersion string `json:"serverVersion,omitempty"`
 	// Capabilities lists the capability constraints the agent requires.
 	Capabilities []capability.Constraint `json:"capabilities"`
 	// DefaultTTL is the default token TTL in seconds.


### PR DESCRIPTION
## Summary

Implements the two remaining open items from `docs/mcp-contract-drift.md`:

- **Fix 2** — `eunox-mcp validate --live`: connects to a running MCP HTTP server, fetches `tools/list`, and reports contract drift in a CI-friendly format with exit codes 0/1/2.
- **Fix 4** — `eunox-mcp init`: generates a deny-all starter manifest from a live upstream's tool list, with every tool commented out and `argumentSchema` inlined from the live `inputSchema`.

Both commands share a new lightweight one-shot MCP HTTP client (`live_upstream.go`) that performs the initialize handshake and `tools/list` fetch without any proxy machinery.

## New files

| File | Purpose |
|---|---|
| `cmd/mcp/live_upstream.go` | Thin MCP HTTP client — `fetchLiveTools` + `liveDoHTTP` |
| `cmd/mcp/validate_live.go` | Drift report formatter — `buildLiveReport`, `runValidateLive` |
| `cmd/mcp/init_manifest.go` | YAML manifest generator — `generateInitManifestYAML` |
| `cmd/mcp/live_upstream_test.go` | 9 tests: happy path, TLS, auth header, cancelled context… |
| `cmd/mcp/validate_live_test.go` | 14 tests: all FM combinations, plural results, section omission… |
| `cmd/mcp/init_manifest_test.go` | 14 tests: schema inlining, sorted properties, all-commented-out invariant… |

## Changed files

- `cmd/mcp/main.go` — `cmdValidate` extended with `--live` and related flags; new `cmdInit` subcommand; updated usage text.
- `cmd/mcp/jsonrpc.go` — suppressed pre-existing `unparam` warning on `notificationMsg` (surfaced by the second call site added in `live_upstream.go`).
- `docs/mcp-contract-drift.md` — Fix 2 and Fix 4 marked ✅ Shipped; priority table and MVP checklist updated.

## validate --live output format

```
Connecting to upstream (https://mcp.example.com)...  ok (7 tools)

COVERED
  ✓ query_db             resource: query_db
  ✓ read_file            resource: read_file

WARNINGS
  ⚠ delete_all_records   resource: delete_*             (glob match — confirm this is intended)
  ⚠ get_customer         resource: get_*                (glob match — confirm this is intended)

NOT COVERED (denied by default)
  - execute_query
  - summarise_text

STALE MANIFEST ENTRIES
  ✗ legacy_search  — no matching upstream tool

Result: 2 glob matches, 1 stale entry. Exit 1.
```

## init output format

```yaml
name: "generated-manifest"
version: "1.0.0"

capabilities:
  # REVIEW: uncomment and add conditions before enabling each tool.
  # - resource: read_file
  #   actions: [call]
  #   argumentSchema:
  #     type: object
  #     properties:
  #       path: { type: string }
  #     required: [path]
  #
  # - resource: query_db
  #   actions: [call]
```

## Test plan

- [ ] `go test ./cmd/mcp/... -count=1` passes (37 new test cases + existing suite)
- [ ] `golangci-lint run ./cmd/mcp/...` reports 0 issues
- [ ] `eunox-mcp validate --help` shows `--live` flags
- [ ] `eunox-mcp init --help` shows expected usage
- [ ] Manual smoke test against a local MCP server (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)